### PR TITLE
feature: host fallback support

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -66,7 +66,7 @@ class ArangoClient:
         self._host_resolver: HostResolver
 
         if host_count == 1:
-            self._host_resolver = SingleHostResolver()
+            self._host_resolver = SingleHostResolver(1, resolver_max_tries)
         elif host_resolver == "random":
             self._host_resolver = RandomHostResolver(host_count, resolver_max_tries)
         else:

--- a/arango/client.py
+++ b/arango/client.py
@@ -31,6 +31,10 @@ class ArangoClient:
         multiple host URLs are provided). Accepted values are "roundrobin" and
         "random". Any other value defaults to round robin.
     :type host_resolver: str
+    :param resolver_max_tries: Number of attempts to process an HTTP request
+        before throwing a ConnectionAbortedError. Must not be lower than the
+        number of hosts.
+    :type resolver_max_tries: int
     :param http_client: User-defined HTTP client.
     :type http_client: arango.http.HTTPClient
     :param serializer: User-defined JSON serializer. Must be a callable
@@ -48,6 +52,7 @@ class ArangoClient:
         self,
         hosts: Union[str, Sequence[str]] = "http://127.0.0.1:8529",
         host_resolver: str = "roundrobin",
+        resolver_max_tries: Optional[int] = None,
         http_client: Optional[HTTPClient] = None,
         serializer: Callable[..., str] = lambda x: dumps(x),
         deserializer: Callable[[str], Any] = lambda x: loads(x),
@@ -63,9 +68,9 @@ class ArangoClient:
         if host_count == 1:
             self._host_resolver = SingleHostResolver()
         elif host_resolver == "random":
-            self._host_resolver = RandomHostResolver(host_count)
+            self._host_resolver = RandomHostResolver(host_count, resolver_max_tries)
         else:
-            self._host_resolver = RoundRobinHostResolver(host_count)
+            self._host_resolver = RoundRobinHostResolver(host_count, resolver_max_tries)
 
         self._http = http_client or DefaultHTTPClient()
         self._serializer = serializer

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -140,7 +140,7 @@ class BaseConnection:
                 return self.prep_response(resp, request.deserialize)
             except ConnectionError:
                 url = self._url_prefixes[host_index] + request.endpoint
-                logging.exception(f"ConnectionError: {url}")
+                logging.error(f"ConnectionError: {url}")
 
                 if len(indexes_to_filter) == self._host_resolver.host_count - 1:
                     indexes_to_filter.clear()

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -6,7 +6,7 @@ __all__ = [
     "JwtSuperuserConnection",
 ]
 
-# import logging
+import logging
 import sys
 import time
 from abc import abstractmethod
@@ -139,7 +139,8 @@ class BaseConnection:
 
                 return self.prep_response(resp, request.deserialize)
             except ConnectionError:
-                # logging.exception("TODO") # TODO
+                url = self._url_prefixes[host_index] + request.endpoint
+                logging.exception(f"ConnectionError: {url}")
 
                 if len(indexes_to_filter) == self._host_resolver.host_count - 1:
                     indexes_to_filter.clear()

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -140,7 +140,7 @@ class BaseConnection:
                 return self.prep_response(resp, request.deserialize)
             except ConnectionError:
                 url = self._url_prefixes[host_index] + request.endpoint
-                logging.error(f"ConnectionError: {url}")
+                logging.debug(f"ConnectionError: {url}")
 
                 if len(indexes_to_filter) == self._host_resolver.host_count - 1:
                     indexes_to_filter.clear()

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -123,7 +123,7 @@ class BaseConnection:
         :rtype: arango.response.Response
         """
         tries = 0
-        while tries < self._host_resolver.max_tries:
+        while tries < self._host_resolver._max_tries:
             try:
                 resp = self._http.send_request(
                     session=self._sessions[host_index],

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -32,19 +32,20 @@ class RandomHostResolver(HostResolver):
     """Random host resolver."""
 
     def __init__(self, host_count: int) -> None:
+        self._max = host_count - 1
         self.max_tries = host_count * 3
-        self._count = host_count
         self._prev_host_indexes: Set[int] = set()
 
     def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
         if prev_host_index is not None:
-            self._prev_host_indexes.add(prev_host_index)
-            if len(self._prev_host_indexes) == self._count:
+            if len(self._prev_host_indexes) == self._max:
                 self._prev_host_indexes.clear()
+
+            self._prev_host_indexes.add(prev_host_index)
 
         host_index = None
         while host_index is None or host_index in self._prev_host_indexes:
-            host_index = random.randint(0, self._count - 1)
+            host_index = random.randint(0, self._max)
 
         return host_index
 

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -53,7 +53,7 @@ class RoundRobinHostResolver(HostResolver):
     """Round-robin host resolver."""
 
     def __init__(self, host_count: int) -> None:
-        self._max_tries = host_count * 3
+        self.max_tries = host_count * 3
         self._index = -1
         self._count = host_count
 

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -13,7 +13,8 @@ from typing import Optional, Set
 class HostResolver(ABC):  # pragma: no cover
     """Abstract base class for host resolvers."""
 
-    def __init__(self, host_count: int = 1, max_tries: int = 3) -> None:
+    def __init__(self, host_count: int = 1, max_tries: Optional[int] = None) -> None:
+        max_tries = max_tries or host_count * 3
         if max_tries < host_count:
             raise ValueError("max_tries cannot be less than host_count")
 
@@ -44,7 +45,7 @@ class RandomHostResolver(HostResolver):
     """Random host resolver."""
 
     def __init__(self, host_count: int, max_tries: Optional[int] = None) -> None:
-        super().__init__(host_count, max_tries or host_count * 3)
+        super().__init__(host_count, max_tries)
 
     def get_host_index(self, indexes_to_filter: Set[int] = set()) -> int:
         host_index = None
@@ -58,7 +59,7 @@ class RoundRobinHostResolver(HostResolver):
     """Round-robin host resolver."""
 
     def __init__(self, host_count: int, max_tries: Optional[int] = None) -> None:
-        super().__init__(host_count, max_tries or host_count * 3)
+        super().__init__(host_count, max_tries)
         self._index = -1
 
     def get_host_index(self, indexes_to_filter: Set[int] = set()) -> int:

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -37,7 +37,7 @@ class RandomHostResolver(HostResolver):
         self._prev_host_indexes: Set[int] = set()
 
     def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
-        if prev_host_index:
+        if prev_host_index is not None:
             self._prev_host_indexes.add(prev_host_index)
             if len(self._prev_host_indexes) == self._count:
                 self._prev_host_indexes.clear()

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -7,20 +7,24 @@ __all__ = [
 
 import random
 from abc import ABC, abstractmethod
+from typing import Optional, Set
 
 
 class HostResolver(ABC):  # pragma: no cover
     """Abstract base class for host resolvers."""
 
+    def __init__(self) -> None:
+        self.max_tries: int = 3
+
     @abstractmethod
-    def get_host_index(self) -> int:
+    def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
         raise NotImplementedError
 
 
 class SingleHostResolver(HostResolver):
     """Single host resolver."""
 
-    def get_host_index(self) -> int:
+    def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
         return 0
 
 
@@ -28,19 +32,31 @@ class RandomHostResolver(HostResolver):
     """Random host resolver."""
 
     def __init__(self, host_count: int) -> None:
-        self._max = host_count - 1
+        self.max_tries = host_count * 3
+        self._count = host_count
+        self._prev_host_indexes: Set[int] = set()
 
-    def get_host_index(self) -> int:
-        return random.randint(0, self._max)
+    def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
+        if prev_host_index:
+            self._prev_host_indexes.add(prev_host_index)
+            if len(self._prev_host_indexes) == self._count:
+                self._prev_host_indexes.clear()
+
+        host_index = None
+        while host_index is None or host_index in self._prev_host_indexes:
+            host_index = random.randint(0, self._count - 1)
+
+        return host_index
 
 
 class RoundRobinHostResolver(HostResolver):
     """Round-robin host resolver."""
 
     def __init__(self, host_count: int) -> None:
+        self._max_tries = host_count * 3
         self._index = -1
         self._count = host_count
 
-    def get_host_index(self) -> int:
+    def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
         self._index = (self._index + 1) % self._count
         return self._index

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -14,7 +14,7 @@ class HostResolver(ABC):  # pragma: no cover
     """Abstract base class for host resolvers."""
 
     def __init__(self) -> None:
-        self.max_tries: int = 3
+        self._max_tries: int = 3
 
     @abstractmethod
     def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
@@ -33,7 +33,7 @@ class RandomHostResolver(HostResolver):
 
     def __init__(self, host_count: int) -> None:
         self._max = host_count - 1
-        self.max_tries = host_count * 3
+        self._max_tries = host_count * 3
         self._prev_host_indexes: Set[int] = set()
 
     def get_host_index(self, prev_host_index: Optional[int] = None) -> int:
@@ -54,7 +54,7 @@ class RoundRobinHostResolver(HostResolver):
     """Round-robin host resolver."""
 
     def __init__(self, host_count: int) -> None:
-        self.max_tries = host_count * 3
+        self._max_tries = host_count * 3
         self._index = -1
         self._count = host_count
 

--- a/arango/resolver.py
+++ b/arango/resolver.py
@@ -22,7 +22,7 @@ class HostResolver(ABC):  # pragma: no cover
         self._max_tries = max_tries
 
     @abstractmethod
-    def get_host_index(self, indexes_to_filter: Set[int] = set()) -> int:
+    def get_host_index(self, indexes_to_filter: Optional[Set[int]] = None) -> int:
         raise NotImplementedError
 
     @property
@@ -37,7 +37,7 @@ class HostResolver(ABC):  # pragma: no cover
 class SingleHostResolver(HostResolver):
     """Single host resolver."""
 
-    def get_host_index(self, indexes_to_filter: Set[int] = set()) -> int:
+    def get_host_index(self, indexes_to_filter: Optional[Set[int]] = None) -> int:
         return 0
 
 
@@ -47,8 +47,9 @@ class RandomHostResolver(HostResolver):
     def __init__(self, host_count: int, max_tries: Optional[int] = None) -> None:
         super().__init__(host_count, max_tries)
 
-    def get_host_index(self, indexes_to_filter: Set[int] = set()) -> int:
+    def get_host_index(self, indexes_to_filter: Optional[Set[int]] = None) -> int:
         host_index = None
+        indexes_to_filter = indexes_to_filter or set()
         while host_index is None or host_index in indexes_to_filter:
             host_index = random.randint(0, self.host_count - 1)
 
@@ -62,6 +63,6 @@ class RoundRobinHostResolver(HostResolver):
         super().__init__(host_count, max_tries)
         self._index = -1
 
-    def get_host_index(self, indexes_to_filter: Set[int] = set()) -> int:
+    def get_host_index(self, indexes_to_filter: Optional[Set[int]] = None) -> int:
         self._index = (self._index + 1) % self.host_count
         return self._index

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -16,6 +16,18 @@ def test_resolver_random_host():
     for _ in range(20):
         assert 0 <= resolver.get_host_index() < 10
 
+    resolver = RandomHostResolver(2)
+    index_a = resolver.get_host_index()
+    index_b = resolver.get_host_index(prev_host_index=index_a)
+    index_c = resolver.get_host_index(prev_host_index=index_b)
+    assert index_c in [index_a, index_b]
+
+    resolver = RandomHostResolver(3)
+    index_a = resolver.get_host_index()
+    index_b = resolver.get_host_index(prev_host_index=index_a)
+    index_c = resolver.get_host_index(prev_host_index=index_b)
+    assert index_c not in [index_a, index_b]
+
 
 def test_resolver_round_robin():
     resolver = RoundRobinHostResolver(10)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,8 +1,17 @@
+from typing import Set
+
+import pytest
+
 from arango.resolver import (
     RandomHostResolver,
     RoundRobinHostResolver,
     SingleHostResolver,
 )
+
+
+def test_bad_resolver():
+    with pytest.raises(ValueError):
+        RandomHostResolver(3, 2)
 
 
 def test_resolver_single_host():
@@ -16,16 +25,19 @@ def test_resolver_random_host():
     for _ in range(20):
         assert 0 <= resolver.get_host_index() < 10
 
-    resolver = RandomHostResolver(2)
-    index_a = resolver.get_host_index()
-    index_b = resolver.get_host_index(prev_host_index=index_a)
-    index_c = resolver.get_host_index(prev_host_index=index_b)
-    assert index_c in [index_a, index_b]
-
     resolver = RandomHostResolver(3)
+    indexes_to_filter: Set[int] = set()
+
     index_a = resolver.get_host_index()
-    index_b = resolver.get_host_index(prev_host_index=index_a)
-    index_c = resolver.get_host_index(prev_host_index=index_b)
+    indexes_to_filter.add(index_a)
+
+    index_b = resolver.get_host_index(indexes_to_filter)
+    indexes_to_filter.add(index_b)
+    assert index_b != index_a
+
+    index_c = resolver.get_host_index(indexes_to_filter)
+    indexes_to_filter.clear()
+    indexes_to_filter.add(index_c)
     assert index_c not in [index_a, index_b]
 
 


### PR DESCRIPTION
Closes #179 

A (working) first-draft implementation for host fallback support.

Requires feedback

What's new:
* `BaseConnection.process_request()`
    * Given a request, process it until a valid response is provided, or the max amount of tries has been reached.
    * `host_index` is still being chosen using the resolver's `get_host_index` method.
* `HostResolver.max_tries : int`
    * A limit to the amount of attempts made to execute the request. Value varies based on the resolver type
* `HostResolver.host_count : int`
    * The number of hosts provided
* `RandomHostResolver.get_host_index()`
    * Reworked to keep track of previously chosen host indexes, to make sure that the next chosen host_index is not one of them.