### PR TITLE
new: fallback host support for 503 errorNum

### DIFF
--- a/arango/connection.py
+++ b/arango/connection.py
@@ -104,6 +104,8 @@ class BaseConnection:
             if isinstance(resp.body, dict):
                 resp.error_code = resp.body.get("errorNum")
                 resp.error_message = resp.body.get("errorMessage")
+                if resp.status_code == resp.error_code == 503:
+                    raise ConnectionError  # Fallback to another host
         else:
             resp.body = resp.raw_body
 


### PR DESCRIPTION
From a discussion with the ArangoDB Java & Go maintainers (cc @rashtao):

> please note that failover/retry in case of status 503 should happen only in these cases:
     1. the response has body like {"error":true,"errorNum":503,"code":503, ...}, note errorNum=503
     2. the 503 response comes from an intermediate proxy, so it does not contain a json body like the one above
Other 503 responses  with different errorNum should not lead to failover/retry, but just thrown to the caller.