### PR TITLE
[Fix] Make overriding TLS verification optional

### DIFF
--- a/docs/certificates.rst
+++ b/docs/certificates.rst
@@ -9,13 +9,20 @@ By default, self-signed certificates will cause trouble when connecting.
 
     client = ArangoClient(hosts="https://localhost:8529")
 
-In order to make connections work even when using self-signed certificates, the
-`verify_certificates` option can be disabled when creating the `ArangoClient`
-instance:
+To make connections work even when using self-signed certificates, you can
+provide the certificate CA bundle or turn the verification off.
+
+If you want to have fine-grained control over the HTTP connection, you should define
+your HTTP client as described in the :ref:`HTTPClients` section.
+
+The ``ArangoClient`` class provides an option to override the verification behavior,
+no matter what has been defined in the underlying HTTP session.
+You can use this option to disable verification or provide a custom CA bundle without
+defining a custom HTTP Client.
 
 .. code-block:: python
 
-    client = ArangoClient(hosts="https://localhost:8529", verify_certificate=False)
+    client = ArangoClient(hosts="https://localhost:8529", verify_override=False)
 
 This will allow connecting, but the underlying `urllib3` library may still issue
 warnings due to the insecurity of using self-signed certificates.
@@ -26,5 +33,4 @@ application:
 .. code-block:: python
 
     import requests
-    requests.packages.urllib3.disable_warnings() 
-
+    requests.packages.urllib3.disable_warnings()

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -1,3 +1,5 @@
+.. _HTTPClients:
+
 HTTP Clients
 ------------
 


### PR DESCRIPTION

This PR allows overriding the TLS verification behavior.
It defaults to None and thus will have no effect if not explicitly defined.
If it is defined, it allows for enabling/disabling verification and defines a custom CA bundle file or directory as specified by the [requests](https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) library.

Fixes #201