### PR TITLE
Add batch_size parameter in import_bulk method

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -2027,7 +2027,7 @@ class Collection(ApiGroup):
                 return result
             raise DocumentInsertError(resp, request)
 
-        result = []
+        results = []
         for batch in get_batches(documents, batch_size):
             request = Request(
                 method="post",
@@ -2037,9 +2037,9 @@ class Collection(ApiGroup):
                 write=self.name,
             )
 
-            result.append(self._execute(request, response_handler))
+            results.append(self._execute(request, response_handler))
 
-        return result[0] if len(result) == 1 else result
+        return results[0] if len(results) == 1 else results
 
 
 class StandardCollection(Collection):

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1985,10 +1985,15 @@ class Collection(ApiGroup):
         :type on_duplicate: str
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param batch_size: Max number of documents to import at once. If
-            unspecified, will import all documents at once. Note that the
-            output type changes to list[dict] if **batch_size** is specified.
-        :type batch_size: int | None
+        :param batch_size: Split up **documents** into batches of max length
+            **batch_size** and import them in a loop on the client side. If
+            **batch_size** is specified, the return type of this method
+            changes from a result object to a list of result objects.
+            IMPORTANT NOTE: this parameter may go through breaking changes
+            in the future where the return type may not be a list of result
+            objects anymore. Use it at your own risk, and avoid
+            depending on the return value if possible.
+        :type batch_size: int
         :return: Result of the bulk import.
         :rtype: dict | list[dict]
         :raise arango.exceptions.DocumentInsertError: If import fails.

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -189,7 +189,7 @@ class Collection(ApiGroup):
             body = body.copy()
             body["_key"] = doc_id[len(self._id_prefix) :]
             return body
-        elif index:
+        elif index is not None:
             body = body.copy()
             body["_key"] = str(index)
             return body

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -2022,19 +2022,29 @@ class Collection(ApiGroup):
                 return result
             raise DocumentInsertError(resp, request)
 
-        results = []
-        for batch in get_batches(documents, batch_size or len(documents)):
+        if batch_size is None:
             request = Request(
                 method="post",
                 endpoint="/_api/import",
-                data=batch,
+                data=documents,
                 params=params,
                 write=self.name,
             )
 
-            results.append(self._execute(request, response_handler))
+            return self._execute(request, response_handler)
+        else:
+            results = []
+            for batch in get_batches(documents, batch_size):
+                request = Request(
+                    method="post",
+                    endpoint="/_api/import",
+                    data=batch,
+                    params=params,
+                    write=self.name,
+                )
+                results.append(self._execute(request, response_handler))
 
-        return results[0] if batch_size is None else results
+            return results
 
 
 class StandardCollection(Collection):

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1986,10 +1986,11 @@ class Collection(ApiGroup):
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
         :param batch_size: Max number of documents to import at once. If
-            unspecified, will import all documents at once.
+            unspecified, will import all documents at once. Note that the
+            output type changes to list[dict] if **batch_size** is specified.
         :type batch_size: int | None
         :return: Result of the bulk import.
-        :rtype: dict
+        :rtype: dict | list[dict]
         :raise arango.exceptions.DocumentInsertError: If import fails.
         """
         documents = [self._ensure_key_from_id(doc) for doc in documents]

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -169,18 +169,13 @@ class Collection(ApiGroup):
             else:
                 return doc_id, doc_id, {"If-Match": rev}
 
-    def _ensure_key_in_body(self, body: Json, index: Optional[int] = None) -> Json:
-        """Return the document body with "_key" field populated. If
-            neither "_key" or "_id" exist, set "_key" value to **index**,
-            where **index** is the document's position in the sequence.
-
+    def _ensure_key_in_body(self, body: Json) -> Json:
+        """Return the document body with "_key" field populated.
         :param body: Document body.
         :type body: dict
-        :param index: Document index value in the original list of documents.
-        :param index: int | None
         :return: Document body with "_key" field.
         :rtype: dict
-        :raise arango.exceptions.DocumentParseError: On missing _key, _id, & index.
+        :raise arango.exceptions.DocumentParseError: On missing ID and key.
         """
         if "_key" in body:
             return body
@@ -189,11 +184,6 @@ class Collection(ApiGroup):
             body = body.copy()
             body["_key"] = doc_id[len(self._id_prefix) :]
             return body
-        elif index is not None:
-            body = body.copy()
-            body["_key"] = str(index)
-            return body
-
         raise DocumentParseError('field "_key" or "_id" required')
 
     def _ensure_key_from_id(self, body: Json) -> Json:
@@ -2001,9 +1991,7 @@ class Collection(ApiGroup):
         :rtype: dict
         :raise arango.exceptions.DocumentInsertError: If import fails.
         """
-        documents = [
-            self._ensure_key_in_body(doc, i) for i, doc in enumerate(documents, 1)
-        ]
+        documents = [self._ensure_key_from_id(doc) for doc in documents]
 
         params: Params = {"type": "array", "collection": self.name}
         if halt_on_error is not None:

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -198,6 +198,7 @@ class Collection(ApiGroup):
 
     def _ensure_key_from_id(self, body: Json) -> Json:
         """Return the body with "_key" field if it has "_id" field.
+
         :param body: Document body.
         :type body: dict
         :return: Document body with "_key" field if it has "_id" field.

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -171,6 +171,7 @@ class Collection(ApiGroup):
 
     def _ensure_key_in_body(self, body: Json) -> Json:
         """Return the document body with "_key" field populated.
+
         :param body: Document body.
         :type body: dict
         :return: Document body with "_key" field.

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -2034,7 +2034,7 @@ class Collection(ApiGroup):
 
             results.append(self._execute(request, response_handler))
 
-        return results[0] if len(results) == 1 else results
+        return results[0] if batch_size is None else results
 
 
 class StandardCollection(Collection):

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -2017,7 +2017,7 @@ class Collection(ApiGroup):
             raise DocumentInsertError(resp, request)
 
         results = []
-        for batch in get_batches(documents, batch_size):
+        for batch in get_batches(documents, batch_size or len(documents)):
             request = Request(
                 method="post",
                 endpoint="/_api/import",

--- a/arango/database.py
+++ b/arango/database.py
@@ -1217,9 +1217,6 @@ class Database(ApiGroup):
             parameter cannot be larger than that of **replication_factor**.
             Default value is 1. Used for clusters only.
         :type write_concern: int
-        :param collections: A list collection data objects to provision
-            the graph with. See below for example.
-        :type collections: dict | None
         :return: Graph API wrapper.
         :rtype: arango.graph.Graph
         :raise arango.exceptions.GraphCreateError: If create fails.

--- a/arango/database.py
+++ b/arango/database.py
@@ -1170,7 +1170,6 @@ class Database(ApiGroup):
         shard_count: Optional[int] = None,
         replication_factor: Optional[int] = None,
         write_concern: Optional[int] = None,
-        collections: Optional[Json] = None,
     ) -> Result[Graph]:
         """Create a new graph.
 
@@ -1236,32 +1235,6 @@ class Database(ApiGroup):
                     'to_vertex_collections': ['lectures']
                 }
             ]
-
-        Here is an example entry for parameter **collections**:
-        TODO: Rework **collections** data structure?
-        .. code-block:: python
-
-            {
-                'teachers': {
-                    'docs': teacher_vertices_to_insert
-                    'options': {
-                        'overwrite' = True,
-                        'sync' = True,
-                        'batch_size' = 50
-                    }
-                },
-                'lectures': {
-                    'docs': lecture_vertices_to_insert
-                    'options': {
-                        'overwrite' = False,
-                        'sync' = False,
-                        'batch_size' = 4
-                    }
-                },
-                'teach': {
-                    'docs': teach_edges_to_insert
-                }
-            }
         """
         data: Json = {"name": name, "options": dict()}
         if edge_definitions is not None:
@@ -1295,15 +1268,7 @@ class Database(ApiGroup):
                 return Graph(self._conn, self._executor, name)
             raise GraphCreateError(resp, request)
 
-        graph = self._execute(request, response_handler)
-
-        if collections is not None:
-            for name, data in collections.items():
-                self.collection(name).import_bulk(
-                    data["docs"], **data.get("options", {})
-                )
-
-        return graph
+        return self._execute(request, response_handler)
 
     def delete_graph(
         self,

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -8,7 +8,7 @@ __all__ = [
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Iterator, List, Optional, Sequence, Union
+from typing import Any, Iterator, Sequence, Union
 
 from arango.exceptions import DocumentParseError
 from arango.typings import Json
@@ -84,25 +84,14 @@ def is_none_or_str(obj: Any) -> bool:
     return obj is None or isinstance(obj, str)
 
 
-def get_batches(
-    l: Sequence[Json], batch_size: Optional[int] = None
-) -> Union[List[Sequence[Json]], Iterator[Sequence[Json]]]:
+def get_batches(elements: Sequence[Json], batch_size: int) -> Iterator[Sequence[Json]]:
     """Generator to split a list in batches
         of (maximum) **batch_size** elements each.
-        If **batch_size** is invalid, return entire
-        list as one batch.
 
-    :param l: The list of elements.
-    :type l: list
+    :param elements: The list of elements.
+    :type elements: Sequence[Json]
     :param batch_size: Number of elements per batch.
-    :type batch_size: int | None
+    :type batch_size: int
     """
-    if batch_size is None or batch_size <= 0 or batch_size >= len(l):
-        return [l]
-
-    def generator() -> Iterator[Sequence[Json]]:
-        n = int(batch_size)  # type: ignore # (false positive)
-        for i in range(0, len(l), n):
-            yield l[i : i + n]
-
-    return generator()
+    for index in range(0, len(elements), batch_size):
+        yield elements[index : index + batch_size]

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -90,7 +90,7 @@ def get_batches(elements: Sequence[Json], batch_size: int) -> Iterator[Sequence[
 
     :param elements: The list of elements.
     :type elements: Sequence[Json]
-    :param batch_size: Number of elements per batch.
+    :param batch_size: Max number of elements per batch.
     :type batch_size: int
     """
     for index in range(0, len(elements), batch_size):

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -8,7 +8,7 @@ __all__ = [
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Iterator, Union
+from typing import Any, Iterator, List, Optional, Union
 
 from arango.exceptions import DocumentParseError
 from arango.typings import Json
@@ -82,3 +82,27 @@ def is_none_or_str(obj: Any) -> bool:
     :rtype: bool
     """
     return obj is None or isinstance(obj, str)
+
+
+def get_batches(
+    l: List[Any], batch_size: Optional[int] = None
+) -> Union[List[List[Any]], Iterator[List[Any]]]:
+    """Generator to split a list in batches
+        of (maximum) **batch_size** elements each.
+        If **batch_size** is invalid, return entire
+        list as one batch.
+
+    :param l: The list of elements.
+    :type l: list
+    :param batch_size: Number of elements per batch.
+    :type batch_size: int | None
+    """
+    if batch_size is None or batch_size <= 0 or batch_size >= len(l):
+        return [l]
+
+    def generator() -> Iterator[List[Any]]:
+        n = int(batch_size)  # type: ignore # (false positive)
+        for i in range(0, len(l), n):
+            yield l[i : i + n]
+
+    return generator()

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -8,7 +8,7 @@ __all__ = [
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Iterator, List, Optional, Sequence, Union
 
 from arango.exceptions import DocumentParseError
 from arango.typings import Json
@@ -85,8 +85,8 @@ def is_none_or_str(obj: Any) -> bool:
 
 
 def get_batches(
-    l: List[Any], batch_size: Optional[int] = None
-) -> Union[List[List[Any]], Iterator[List[Any]]]:
+    l: Sequence[Json], batch_size: Optional[int] = None
+) -> Union[List[Sequence[Json]], Iterator[Sequence[Json]]]:
     """Generator to split a list in batches
         of (maximum) **batch_size** elements each.
         If **batch_size** is invalid, return entire
@@ -100,7 +100,7 @@ def get_batches(
     if batch_size is None or batch_size <= 0 or batch_size >= len(l):
         return [l]
 
-    def generator() -> Iterator[List[Any]]:
+    def generator() -> Iterator[Sequence[Json]]:
         n = int(batch_size)  # type: ignore # (false positive)
         for i in range(0, len(l), n):
             yield l[i : i + n]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1839,7 +1839,8 @@ def test_document_import_bulk(col, bad_col, docs):
     empty_collection(col)
 
     result = col.import_bulk(docs, batch_size=len(docs) * 2)
-    assert type(result) is dict
+    assert type(result) is list
+    assert len(result) == 1
     empty_collection(col)
 
     # Test import bulk on_duplicate actions

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1832,6 +1832,14 @@ def test_document_import_bulk(col, bad_col, docs):
         assert col[doc_key]["loc"] == doc["loc"]
     empty_collection(col)
 
+    # Test import bulk with batch_size
+    results = col.import_bulk(docs, batch_size=len(docs) // 2)
+    assert type(results) is list
+    assert len(results) == 2
+
+    result = col.import_bulk(docs, batch_size=len(docs) * 2)
+    assert type(result) is dict
+
     # Test import bulk on_duplicate actions
     doc = docs[0]
     doc_key = doc["_key"]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1836,9 +1836,11 @@ def test_document_import_bulk(col, bad_col, docs):
     results = col.import_bulk(docs, batch_size=len(docs) // 2)
     assert type(results) is list
     assert len(results) == 2
+    empty_collection(col)
 
     result = col.import_bulk(docs, batch_size=len(docs) * 2)
     assert type(result) is dict
+    empty_collection(col)
 
     # Test import bulk on_duplicate actions
     doc = docs[0]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -72,8 +72,11 @@ def test_graph_provision(graph, db):
             "to_vertex_collections": ["numbers"],
         }
     ]
+
+    name = "divisibility-graph"
+    db.delete_graph(name, drop_collections=True, ignore_missing=True)
     graph = db.create_graph(
-        name="DivisibilityGraph",
+        name=name,
         edge_definitions=e_d,
         collections={
             "numbers": {"docs": vertices, "options": {"batch_size": 5}},

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -58,7 +58,7 @@ def test_graph_properties(graph, bad_graph, db):
 
 
 def test_graph_provision(graph, db):
-    vertices = [{"foo": i} for i in range(1, 101)]
+    vertices = [{"_key": str(i)} for i in range(1, 101)]
     edges = [
         {"_from": f"numbers/{j}", "_to": f"numbers/{i}", "result": j / i}
         for i in range(1, 101)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -57,6 +57,34 @@ def test_graph_properties(graph, bad_graph, db):
     assert isinstance(properties["revision"], str)
 
 
+def test_graph_provision(graph, db):
+    vertices = [{"foo": i} for i in range(1, 101)]
+    edges = [
+        {"_from": f"numbers/{j}", "_to": f"numbers/{i}", "result": j / i}
+        for i in range(1, 101)
+        for j in range(1, 101)
+        if j % i == 0
+    ]
+    e_d = [
+        {
+            "edge_collection": "is_divisible_by",
+            "from_vertex_collections": ["numbers"],
+            "to_vertex_collections": ["numbers"],
+        }
+    ]
+    graph = db.create_graph(
+        name="DivisibilityGraph",
+        edge_definitions=e_d,
+        collections={
+            "numbers": {"docs": vertices, "options": {"batch_size": 5}},
+            "is_divisible_by": {"docs": edges, "options": {"sync": True}},
+        },
+    )
+
+    assert graph.vertex_collection("numbers").count() == len(vertices)
+    assert graph.edge_collection("is_divisible_by").count() == len(edges)
+
+
 def test_graph_management(db, bad_db):
     # Test create graph
     graph_name = generate_graph_name()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -57,37 +57,6 @@ def test_graph_properties(graph, bad_graph, db):
     assert isinstance(properties["revision"], str)
 
 
-def test_graph_provision(graph, db):
-    vertices = [{"_key": str(i)} for i in range(1, 101)]
-    edges = [
-        {"_from": f"numbers/{j}", "_to": f"numbers/{i}", "result": j / i}
-        for i in range(1, 101)
-        for j in range(1, 101)
-        if j % i == 0
-    ]
-    e_d = [
-        {
-            "edge_collection": "is_divisible_by",
-            "from_vertex_collections": ["numbers"],
-            "to_vertex_collections": ["numbers"],
-        }
-    ]
-
-    name = "divisibility-graph"
-    db.delete_graph(name, drop_collections=True, ignore_missing=True)
-    graph = db.create_graph(
-        name=name,
-        edge_definitions=e_d,
-        collections={
-            "numbers": {"docs": vertices, "options": {"batch_size": 5}},
-            "is_divisible_by": {"docs": edges, "options": {"sync": True}},
-        },
-    )
-
-    assert graph.vertex_collection("numbers").count() == len(vertices)
-    assert graph.edge_collection("is_divisible_by").count() == len(edges)
-
-
 def test_graph_management(db, bad_db):
     # Test create graph
     graph_name = generate_graph_name()


### PR DESCRIPTION
Introduces batch insertion via the `import_bulk` API.

These changes warrant a minor version increment.

### Demo

```py
vertices = [{'foo': str(i)} for i in range(1, 101)]
db.create_collection('numbers')
results = db.collection('numbers').import_bulk(vertices, batch_size=len(vertices)//10)
assert len(results) == 10
```