### PR TITLE
Prevent batch_size parameter usage when overwrite is set to True in bulk_import  

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1992,12 +1992,16 @@ class Collection(ApiGroup):
             IMPORTANT NOTE: this parameter may go through breaking changes
             in the future where the return type may not be a list of result
             objects anymore. Use it at your own risk, and avoid
-            depending on the return value if possible.
+            depending on the return value if possible. Should not be used
+            if **overwrite** is set to true.
         :type batch_size: int
         :return: Result of the bulk import.
         :rtype: dict | list[dict]
         :raise arango.exceptions.DocumentInsertError: If import fails.
         """
+        if overwrite and batch_size:
+            raise ValueError("Cannot set **batch_size** if **overwrite** is true")
+
         documents = [self._ensure_key_from_id(doc) for doc in documents]
 
         params: Params = {"type": "array", "collection": self.name}

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1992,15 +1992,16 @@ class Collection(ApiGroup):
             IMPORTANT NOTE: this parameter may go through breaking changes
             in the future where the return type may not be a list of result
             objects anymore. Use it at your own risk, and avoid
-            depending on the return value if possible. Should not be used
-            if **overwrite** is set to true.
+            depending on the return value if possible. Cannot be used with
+            parameter **overwrite**.
         :type batch_size: int
         :return: Result of the bulk import.
         :rtype: dict | list[dict]
         :raise arango.exceptions.DocumentInsertError: If import fails.
         """
-        if overwrite and batch_size:
-            raise ValueError("Cannot set **batch_size** if **overwrite** is true")
+        if overwrite and batch_size is not None:
+            msg = "Cannot use parameter 'batch_size' if 'overwrite' is set to True"
+            raise ValueError(msg)
 
         documents = [self._ensure_key_from_id(doc) for doc in documents]
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1842,7 +1842,7 @@ def test_document_import_bulk(col, bad_col, docs):
     assert type(result) is list
     assert len(result) == 1
     empty_collection(col)
-    
+
     # Test import bulk with overwrite and batch_size
     with pytest.raises(ValueError):
         col.import_bulk(docs, overwrite=True, batch_size=1)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1842,6 +1842,10 @@ def test_document_import_bulk(col, bad_col, docs):
     assert type(result) is list
     assert len(result) == 1
     empty_collection(col)
+    
+    # Test import bulk with overwrite and batch_size
+    with pytest.raises(ValueError):
+        col.import_bulk(docs, overwrite=True, batch_size=1)
 
     # Test import bulk on_duplicate actions
     doc = docs[0]


### PR DESCRIPTION
Now that `batch_size` has been introduced to `import_bulk()`, we should be checking that users don't use both the `overwrite` and the `batch_size` parameters in the same call.

If server-side batching is ever introduced to `/_api/import`, then this restriction could most likely be lifted.

Warrants a 7.4.1 release