### PR TITLE
Add 'read_timeout' option in client.py

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -59,7 +59,7 @@ class ArangoClient:
        request timeout set in the http client.
        None: No timeout.
        int: Timeout value in seconds.
-    :type request_timeout: Optional[int]
+    :type request_timeout: Any
     """
 
     def __init__(

--- a/arango/client.py
+++ b/arango/client.py
@@ -54,9 +54,8 @@ class ArangoClient:
        str: Path to a custom CA bundle file or directory.
     :type verify_override: Union[bool, str, None]
     :param request_timeout: This is the default request timeout (in seconds)
-       for http requests issued by the client. The default value is -1.
-       Setting this parameter to any other value, will overwrite your
-       request timeout set in the http client.
+       for http requests issued by the client if the parameter http_client is
+       not secified. The default value is 60.
        None: No timeout.
        int: Timeout value in seconds.
     :type request_timeout: Any
@@ -71,7 +70,7 @@ class ArangoClient:
         serializer: Callable[..., str] = lambda x: dumps(x),
         deserializer: Callable[[str], Any] = lambda x: loads(x),
         verify_override: Union[bool, str, None] = None,
-        request_timeout: Any = -1,
+        request_timeout: Any = 60,
     ) -> None:
         if isinstance(hosts, str):
             self._hosts = [host.strip("/") for host in hosts.split(",")]
@@ -92,7 +91,7 @@ class ArangoClient:
         self._http = http_client or DefaultHTTPClient()
         # Sets the request timeout.
         # This call can only happen AFTER initializing the http client.
-        if request_timeout != -1:
+        if http_client is None:
             self.request_timeout = request_timeout
 
         self._serializer = serializer

--- a/arango/client.py
+++ b/arango/client.py
@@ -53,6 +53,13 @@ class ArangoClient:
        False: Do not verify TLS certificate.
        str: Path to a custom CA bundle file or directory.
     :type verify_override: Union[bool, str, None]
+    :param request_timeout: This is the default request timeout (in seconds)
+       for http requests issued by the client. The default value is -1.
+       Setting this parameter to any other value, will overwrite your
+       request timeout set in the http client.
+       None: No timeout.
+       int: Timeout value in seconds.
+    :type request_timeout: Optional[int]
     """
 
     def __init__(
@@ -64,6 +71,7 @@ class ArangoClient:
         serializer: Callable[..., str] = lambda x: dumps(x),
         deserializer: Callable[[str], Any] = lambda x: loads(x),
         verify_override: Union[bool, str, None] = None,
+        request_timeout: Any = -1,
     ) -> None:
         if isinstance(hosts, str):
             self._hosts = [host.strip("/") for host in hosts.split(",")]
@@ -80,7 +88,13 @@ class ArangoClient:
         else:
             self._host_resolver = RoundRobinHostResolver(host_count, resolver_max_tries)
 
+        # Initializes the http client
         self._http = http_client or DefaultHTTPClient()
+        # Sets the request timeout.
+        # This call can only happen AFTER initializing the http client.
+        if request_timeout != -1:
+            self.request_timeout = request_timeout
+
         self._serializer = serializer
         self._deserializer = deserializer
         self._sessions = [self._http.create_session(h) for h in self._hosts]
@@ -116,6 +130,20 @@ class ArangoClient:
         """
         version: str = get_distribution("python-arango").version
         return version
+
+    @property
+    def request_timeout(self) -> Any:
+        """Return the request timeout of the http client.
+
+        :return: Request timeout.
+        :rtype: Any
+        """
+        return self._http.REQUEST_TIMEOUT  # type: ignore
+
+    # Setter for request_timeout
+    @request_timeout.setter
+    def request_timeout(self, value: Any) -> None:
+        self._http.REQUEST_TIMEOUT = value  # type: ignore
 
     def db(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,7 +52,12 @@ def test_client_attributes():
     assert client.hosts == client_hosts
     assert repr(client) == client_repr
     assert isinstance(client._host_resolver, RandomHostResolver)
-
+    
+    client = ArangoClient(
+        hosts=client_hosts,
+        request_timeout=120
+    )
+    assert client.request_timeout == client._http.REQUEST_TIMEOUT == 120
 
 def test_client_good_connection(db, username, password):
     client = ArangoClient(hosts="http://127.0.0.1:8529")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,12 +52,10 @@ def test_client_attributes():
     assert client.hosts == client_hosts
     assert repr(client) == client_repr
     assert isinstance(client._host_resolver, RandomHostResolver)
-    
-    client = ArangoClient(
-        hosts=client_hosts,
-        request_timeout=120
-    )
+
+    client = ArangoClient(hosts=client_hosts, request_timeout=120)
     assert client.request_timeout == client._http.REQUEST_TIMEOUT == 120
+
 
 def test_client_good_connection(db, username, password):
     client = ArangoClient(hosts="http://127.0.0.1:8529")


### PR DESCRIPTION
- Added `request_timeout` property to `ArangoClient` to overwrite `DefaultHTTPClient.REQUEST_TIMEOUT`
- Added `request_timeout` constructor parameter in `ArangoClient` to initialize `request_timeout` property. The default value for this parameter is -1. Any other value supplied, including `None` will overwrite `DefaultHTTPClient.REQUEST_TIMEOUT` 
- Added `# type: ignore` to lines 141 and 146 because they failed `mypy`. However, they work perfectly well when tested. Any suggestions here is very much appreciated.