### PR TITLE
3.10: Implemented query rules endpoint

### DIFF
--- a/arango/aql.py
+++ b/arango/aql.py
@@ -19,10 +19,10 @@ from arango.exceptions import (
     AQLQueryExplainError,
     AQLQueryKillError,
     AQLQueryListError,
+    AQLQueryRulesGetError,
     AQLQueryTrackingGetError,
     AQLQueryTrackingSetError,
     AQLQueryValidateError,
-    AQLQueryRulesGetError,
 )
 from arango.executor import ApiExecutor
 from arango.formatter import (

--- a/arango/aql.py
+++ b/arango/aql.py
@@ -22,6 +22,7 @@ from arango.exceptions import (
     AQLQueryTrackingGetError,
     AQLQueryTrackingSetError,
     AQLQueryValidateError,
+    AQLQueryRulesGetError,
 )
 from arango.executor import ApiExecutor
 from arango.formatter import (
@@ -30,6 +31,7 @@ from arango.formatter import (
     format_aql_tracking,
     format_body,
     format_query_cache_entry,
+    format_query_rule_item,
 )
 from arango.request import Request
 from arango.response import Response
@@ -630,5 +632,26 @@ class AQL(ApiGroup):
             if not resp.is_success:
                 raise AQLFunctionDeleteError(resp, request)
             return {"deleted": resp.body["deletedCount"]}
+
+        return self._execute(request, response_handler)
+
+    def query_rules(self) -> Result[Jsons]:
+        """Return the available optimizer rules for AQL queries
+
+        :return: The available optimizer rules for AQL queries
+        :rtype: dict
+        :raise arango.exceptions.AQLQueryRulesGetError: If retrieval fails.
+        """
+        request = Request(method="get", endpoint="/_api/query/rules")
+
+        def response_handler(resp: Response) -> Jsons:
+            if not resp.is_success:
+                raise AQLQueryRulesGetError(resp, request)
+
+            rules: Jsons = resp.body
+            items: Jsons = []
+            for rule in rules:
+                items.append(format_query_rule_item(rule))
+            return items
 
         return self._execute(request, response_handler)

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -153,6 +153,10 @@ class AQLFunctionDeleteError(ArangoServerError):
     """Failed to delete AQL user function."""
 
 
+class AQLQueryRulesGetError(ArangoServerError):
+    """Failed to retrieve AQL query rules."""
+
+
 ##############################
 # Async Execution Exceptions #
 ##############################

--- a/arango/formatter.py
+++ b/arango/formatter.py
@@ -1141,3 +1141,47 @@ def format_query_cache_entry(body: Json) -> Json:
         result["data_sources"] = body["dataSources"]
 
     return verify_format(body, result)
+
+
+def format_query_rule_item(body: Json) -> Json:
+    """Format AQL query rule item.
+
+    :param body: Input body.
+    :type body: dict
+    :return: Formatted body.
+    :rtype: dict
+    """
+    result = {}
+
+    if "name" in body:
+        result["name"] = body["name"]
+    if "flags" in body:
+        result["flags"] = format_query_rule_item_flags(body["flags"])
+
+    return verify_format(body, result)
+
+
+def format_query_rule_item_flags(body: Json) -> Json:
+    """Format AQL query rule item flags.
+
+    :param body: Input body.
+    :type body: dict
+    :return: Formatted body.
+    :rtype: dict
+    """
+    result = {}
+
+    if "hidden" in body:
+        result["hidden"] = body["hidden"]
+    if "clusterOnly" in body:
+        result["clusterOnly"] = body["clusterOnly"]
+    if "canBeDisabled" in body:
+        result["canBeDisabled"] = body["canBeDisabled"]
+    if "canCreateAdditionalPlans" in body:
+        result["canCreateAdditionalPlans"] = body["canCreateAdditionalPlans"]
+    if "disabledByDefault" in body:
+        result["disabledByDefault"] = body["disabledByDefault"]
+    if "enterpriseOnly" in body:
+        result["enterpriseOnly"] = body["enterpriseOnly"]
+
+    return verify_format(body, result)


### PR DESCRIPTION
Added support for the GET /_api/query/rules endpoint that returns the available optimizer rules for AQL queries.
https://github.com/arangodb/docs/blob/main/3.10/release-notes-api-changes310.md#optimizer-rules-for-aql-queries