### PR TITLE
3.10: Read from Followers (allow dirty read)

### DIFF
--- a/arango/aql.py
+++ b/arango/aql.py
@@ -266,7 +266,7 @@ class AQL(ApiGroup):
         skip_inaccessible_cols: Optional[bool] = None,
         max_runtime: Optional[Number] = None,
         fill_block_cache: Optional[bool] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Cursor]:
         """Execute the query and return the result cursor.
 

--- a/arango/aql.py
+++ b/arango/aql.py
@@ -266,6 +266,7 @@ class AQL(ApiGroup):
         skip_inaccessible_cols: Optional[bool] = None,
         max_runtime: Optional[Number] = None,
         fill_block_cache: Optional[bool] = None,
+        allow_dirty_read: Optional[bool] = None,
     ) -> Result[Cursor]:
         """Execute the query and return the result cursor.
 
@@ -358,6 +359,8 @@ class AQL(ApiGroup):
             query will not make it into the RocksDB block cache if not already
             in there, thus leaving more room for the actual hot set.
         :type fill_block_cache: bool
+        :param allow_dirty_read: Allow reads from followers in a cluster.
+        :type allow_dirty_read: bool | None
         :return: Result cursor.
         :rtype: arango.cursor.Cursor
         :raise arango.exceptions.AQLQueryExecuteError: If execute fails.
@@ -408,7 +411,12 @@ class AQL(ApiGroup):
             data["options"] = options
         data.update(options)
 
-        request = Request(method="post", endpoint="/_api/cursor", data=data)
+        request = Request(
+            method="post",
+            endpoint="/_api/cursor",
+            data=data,
+            headers={"x-arango-allow-dirty-read": "true"} if allow_dirty_read else None,
+        )
 
         def response_handler(resp: Response) -> Cursor:
             if not resp.is_success:

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -511,7 +511,7 @@ class Collection(ApiGroup):
         document: Union[str, Json],
         rev: Optional[str] = None,
         check_rev: bool = True,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[bool]:
         """Check if a document exists in the collection.
 
@@ -672,7 +672,7 @@ class Collection(ApiGroup):
         latitude: Number,
         longitude: Number,
         limit: Optional[int] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Cursor]:
         """Return documents near a given coordinate.
 
@@ -734,7 +734,7 @@ class Collection(ApiGroup):
         upper: int,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Cursor]:
         """Return documents within a given range in a random order.
 
@@ -796,7 +796,7 @@ class Collection(ApiGroup):
         longitude: Number,
         radius: Number,
         distance_field: Optional[str] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Cursor]:
         """Return documents within a given radius around a coordinate.
 
@@ -924,7 +924,7 @@ class Collection(ApiGroup):
         field: str,
         query: str,
         limit: Optional[int] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Cursor]:
         """Return documents that match the given fulltext query.
 
@@ -975,7 +975,7 @@ class Collection(ApiGroup):
     def get_many(
         self,
         documents: Sequence[Union[str, Json]],
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[List[Json]]:
         """Return multiple documents ignoring any missing ones.
 
@@ -2089,7 +2089,7 @@ class StandardCollection(Collection):
         document: Union[str, Json],
         rev: Optional[str] = None,
         check_rev: bool = True,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Optional[Json]]:
         """Return a document.
 
@@ -3119,7 +3119,7 @@ class EdgeCollection(Collection):
         self,
         vertex: Union[str, Json],
         direction: Optional[str] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Json]:
         """Return the edge documents coming in and/or out of the vertex.
 

--- a/arango/database.py
+++ b/arango/database.py
@@ -290,7 +290,7 @@ class Database(ApiGroup):
             endpoint="/_api/transaction",
             data=data,
             headers={"x-arango-allow-dirty-read": "true"} if allow_dirty_read else None,
-            )
+        )
 
         def response_handler(resp: Response) -> Any:
             if not resp.is_success:

--- a/arango/database.py
+++ b/arango/database.py
@@ -224,6 +224,7 @@ class Database(ApiGroup):
         allow_implicit: Optional[bool] = None,
         intermediate_commit_count: Optional[int] = None,
         intermediate_commit_size: Optional[int] = None,
+        allow_dirty_read: Optional[bool] = None,
     ) -> Result[Any]:
         """Execute raw Javascript command in transaction.
 
@@ -256,6 +257,8 @@ class Database(ApiGroup):
         :param intermediate_commit_size: Max size of operations in bytes after
             which an intermediate commit is performed automatically.
         :type intermediate_commit_size: int | None
+        :param allow_dirty_read: Allow reads from followers in a cluster.
+        :type allow_dirty_read: bool | None
         :return: Return value of **command**.
         :rtype: Any
         :raise arango.exceptions.TransactionExecuteError: If execution fails.
@@ -282,7 +285,12 @@ class Database(ApiGroup):
         if intermediate_commit_size is not None:
             data["intermediateCommitSize"] = intermediate_commit_size
 
-        request = Request(method="post", endpoint="/_api/transaction", data=data)
+        request = Request(
+            method="post",
+            endpoint="/_api/transaction",
+            data=data,
+            headers={"x-arango-allow-dirty-read": "true"} if allow_dirty_read else None,
+            )
 
         def response_handler(resp: Response) -> Any:
             if not resp.is_success:

--- a/arango/database.py
+++ b/arango/database.py
@@ -224,7 +224,7 @@ class Database(ApiGroup):
         allow_implicit: Optional[bool] = None,
         intermediate_commit_count: Optional[int] = None,
         intermediate_commit_size: Optional[int] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> Result[Any]:
         """Execute raw Javascript command in transaction.
 

--- a/arango/executor.py
+++ b/arango/executor.py
@@ -307,7 +307,7 @@ class TransactionApiExecutor:
         allow_implicit: Optional[bool] = None,
         lock_timeout: Optional[int] = None,
         max_size: Optional[int] = None,
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> None:
         self._conn = connection
 
@@ -360,7 +360,7 @@ class TransactionApiExecutor:
         self,
         request: Request,
         response_handler: Callable[[Response], T],
-        allow_dirty_read: Optional[bool] = None,
+        allow_dirty_read: bool = False,
     ) -> T:
         """Execute API request in a transaction and return the result.
 

--- a/arango/executor.py
+++ b/arango/executor.py
@@ -333,8 +333,8 @@ class TransactionApiExecutor:
             method="post",
             endpoint="/_api/transaction/begin",
             data=data,
-            headers={"x-arango-allow-dirty-read": "true"} if allow_dirty_read else None
-            )
+            headers={"x-arango-allow-dirty-read": "true"} if allow_dirty_read else None,
+        )
         resp = self._conn.send_request(request)
 
         if not resp.is_success:
@@ -356,10 +356,12 @@ class TransactionApiExecutor:
         """
         return self._id
 
-    def execute(self,
-                request: Request,
-                response_handler: Callable[[Response], T],
-                allow_dirty_read: Optional[bool] = None) -> T:
+    def execute(
+        self,
+        request: Request,
+        response_handler: Callable[[Response], T],
+        allow_dirty_read: Optional[bool] = None,
+    ) -> T:
         """Execute API request in a transaction and return the result.
 
         :param request: HTTP request.


### PR DESCRIPTION
Added `allow_dirty_read` optional parameter to methods for the following:
- Single document reads (`GET /_api/document`)
- Batch document reads (`PUT /_api/document?onlyget=true`)
- Read-only AQL queries (`POST /_api/cursor`)
- The edge API (`GET /_api/edges`)
- Read-only Stream Transactions and their sub-operations (`POST /_api/transaction/begin etc.`)

https://github.com/arangodb/docs/blob/main/3.10/release-notes-api-changes310.md#read-from-followers