### PR TITLE
[fix] Persistent index creation fails.

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1248,7 +1248,7 @@ class Collection(ApiGroup):
         sparse: Optional[bool] = None,
         name: Optional[str] = None,
         in_background: Optional[bool] = None,
-        storedValues: Sequence[str] = [],
+        storedValues: Optional[Sequence[str]] = None,
         cacheEnabled: Optional[bool] = None,
     ) -> Result[Json]:
         """Create a new persistent index.


### PR DESCRIPTION
When updating to ArangoDB 3.10, the driver is no longer able to create persistent indexes.
Error:
```
arango.exceptions.IndexCreateError: [HTTP 400][ERR 10] invalid number of index attributes
```

The value for storedValues is set to an empty list by default which yields an error. 
Instead it should be unset by default.

Plus:
I also realised that the parameters do not adhere to the naming convention in the library.
The parameter should be named `stored_values` instead of `storedValues` (same goes for `cacheEnabled`).
I left the name, but can also fix this as part of this PR if you want me to do this.

Reference: someengineering/resoto#1294
