### PR TITLE
Replace pkg_resources with importlib_metadata

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -3,7 +3,7 @@ __all__ = ["ArangoClient"]
 from json import dumps, loads
 from typing import Any, Callable, Optional, Sequence, Union
 
-from pkg_resources import get_distribution
+import importlib_metadata
 
 from arango.connection import (
     BasicConnection,
@@ -127,7 +127,7 @@ class ArangoClient:
         :return: Client version.
         :rtype: str
         """
-        version: str = get_distribution("python-arango").version
+        version: str = importlib_metadata.version("python-arango")
         return version
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "requests_toolbelt",
         "PyJWT",
         "setuptools>=42",
+        "importlib_metadata>=4.7.1",
     ],
     extras_require={
         "dev": [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,8 @@
 import json
 from typing import Union
 
+import importlib_metadata
 import pytest
-from pkg_resources import get_distribution
 from requests import Session
 
 from arango.client import ArangoClient
@@ -21,7 +21,7 @@ def test_client_attributes():
     http_client = DefaultHTTPClient()
 
     client = ArangoClient(hosts="http://127.0.0.1:8529", http_client=http_client)
-    assert client.version == get_distribution("python-arango").version
+    assert client.version == importlib_metadata.version("python-arango")
     assert client.hosts == ["http://127.0.0.1:8529"]
 
     assert repr(client) == "<ArangoClient http://127.0.0.1:8529>"
@@ -36,7 +36,7 @@ def test_client_attributes():
         serializer=json.dumps,
         deserializer=json.loads,
     )
-    assert client.version == get_distribution("python-arango").version
+    assert client.version == importlib_metadata.version("python-arango")
     assert client.hosts == client_hosts
     assert repr(client) == client_repr
     assert isinstance(client._host_resolver, RoundRobinHostResolver)
@@ -48,7 +48,7 @@ def test_client_attributes():
         serializer=json.dumps,
         deserializer=json.loads,
     )
-    assert client.version == get_distribution("python-arango").version
+    assert client.version == importlib_metadata.version("python-arango")
     assert client.hosts == client_hosts
     assert repr(client) == client_repr
     assert isinstance(client._host_resolver, RandomHostResolver)


### PR DESCRIPTION
Copying description from [issue](https://github.com/ArangoDB-Community/python-arango/issues/249):

`pkg_resources` is now deprecated in favor of `importlib.metadata` / `importlib_metadata` ([source](https://setuptools.pypa.io/en/latest/pkg_resources.html)). Right now it causes warnings and in the future (3.12?) I think it will stop working entirely. I saw there was a related [pr](https://github.com/ArangoDB-Community/python-arango/pull/233) but it was using `importlib.metadata` which apparently has different behaviors on some versions of python and caused issues for some users ([ref](https://github.com/ArangoDB-Community/python-arango/issues/244)). Maybe it would be acceptable to use `importlib_metadata` (the backport) either on all versions of python or only when necessary.