### PR TITLE
[DE-546] Adding stats fields to the explain API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+main
+----
+
+* Adding peak_memory_usage as a new property of AQL queries, available since ArangoDB 3.11.
+
+* The explain method of AQL queries includes the "stats" field in the returned object. Note that the REST API returns
+  it separately from the "plan" field, but for now we have to merge them together to ensure backward compatibility.

--- a/arango/aql.py
+++ b/arango/aql.py
@@ -213,11 +213,19 @@ class AQL(ApiGroup):
             if not resp.is_success:
                 raise AQLQueryExplainError(resp, request)
             if "plan" in resp.body:
-                plan: Json = resp.body["plan"]
-                return plan
+                result: Json = resp.body["plan"]
+                if "stats" in resp.body:
+                    result["stats"] = resp.body["stats"]
+                return result
             else:
-                plans: Jsons = resp.body["plans"]
-                return plans
+                results: Jsons = resp.body["plans"]
+                if "stats" in resp.body:
+                    # Although "plans" contains an array, "stats" is a single object.
+                    # We need to duplicate "stats" for each plan in order to preserve
+                    # the original structure.
+                    for plan in results:
+                        plan["stats"] = resp.body["stats"]
+                return results
 
         return self._execute(request, response_handler)
 

--- a/arango/formatter.py
+++ b/arango/formatter.py
@@ -322,6 +322,10 @@ def format_aql_query(body: Json) -> Json:
         result["stream"] = body["stream"]
     if "user" in body:
         result["user"] = body["user"]
+
+    # New in 3.11
+    if "peakMemoryUsage" in body:
+        result["peak_memory_usage"] = body["peakMemoryUsage"]
     return verify_format(body, result)
 
 

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "7.5.3"
+    driver_version = "7.5.8"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "PyJWT",
         "setuptools>=42",
         "importlib_metadata>=4.7.1",
+        "packaging>=23.1",
     ],
     extras_require={
         "dev": [

--- a/tester.sh
+++ b/tester.sh
@@ -21,7 +21,10 @@ if [[ "$tests" != "all" && "$tests" != "community" && "$tests" != "enterprise" ]
     exit 1
 fi
 
-version="${3:-3.10.6}"
+# 3.11.0
+# 3.10.6
+# 3.9.9
+version="${3:-3.11.0}"
 
 if [[ -n "$4" && "$4" != "notest" ]]; then
     echo "Invalid argument. Use 'notest' to only start the docker container, without running the tests."

--- a/tests/test_aql.py
+++ b/tests/test_aql.py
@@ -33,6 +33,7 @@ def test_aql_query_management(db, bad_db, col, docs):
         "rules",
         "variables",
         "collections",
+        "stats",
     ]
     # Test explain invalid query
     with assert_raises(AQLQueryExplainError) as err:


### PR DESCRIPTION
**Purpose**
Enhance the AQL `explain` functionality by adding the following attributes (available since 3.10.4):
- peakMemoryUsage (number): The maximum memory usage of the query during explain (in bytes)
- executionTime (number): The (wall-clock) time in seconds needed to explain the query.
Note that the explain method of AQL queries includes the "stats" field in the returned object. The REST API returns it separately from the "plan" field, but for now we have to merge them together to ensure backward compatibility.

**Additionally, the following changes are being made**
- Adding peak_memory_usage as a new property of AQL queries, available since ArangoDB 3.11
- Adding a CHANGELOG file for keeping track of changes across driver releases

**Tests**
The necessary tests have been adapted. Note that we have to differentiate now between ArangoDB versions while running the tests.
