### PR TITLE
[DE-544] Adjusting allowRetry implementation

### DIFF
--- a/arango/aql.py
+++ b/arango/aql.py
@@ -313,7 +313,7 @@ class AQL(ApiGroup):
             development to catch issues early. If set to False, warnings are
             returned with the query result. There is a server configuration
             option "--query.fail-on-warning" for setting the default value for
-            this behaviour so it does not need to be set per-query.
+            this behaviour, so it does not need to be set per-query.
         :type fail_on_warning: bool
         :param profile: Return additional profiling details in the cursor,
             unless the query cache is used.
@@ -437,7 +437,7 @@ class AQL(ApiGroup):
         def response_handler(resp: Response) -> Cursor:
             if not resp.is_success:
                 raise AQLQueryExecuteError(resp, request)
-            return Cursor(self._conn, resp.body)
+            return Cursor(self._conn, resp.body, allow_retry=allow_retry)
 
         return self._execute(request, response_handler)
 

--- a/arango/cursor.py
+++ b/arango/cursor.py
@@ -290,7 +290,7 @@ class Cursor:
 
         endpoint = f"/_api/{self._type}/{self._id}"
         if self._allow_retry and self._next_batch_id is not None:
-            endpoint += f"/{self._next_batch_id}"
+            endpoint += f"/{self._next_batch_id}"  # pragma: no cover
 
         request = Request(method="post", endpoint=endpoint)
         resp = self._conn.send_request(request)

--- a/arango/cursor.py
+++ b/arango/cursor.py
@@ -110,8 +110,10 @@ class Cursor:
 
         # New in 3.11
         if "nextBatchId" in data:
-            self._next_batch_id = data["nextBatchId"]
-            result["next_batch_id"] = data["nextBatchId"]
+            # This is only available for server versions 3.11 and above.
+            # Currently, we are testing against 3.10.9
+            self._next_batch_id = data["nextBatchId"]  # pragma: no cover
+            result["next_batch_id"] = data["nextBatchId"]  # pragma: no cover
 
         self._has_more = bool(data["hasMore"])
         result["has_more"] = data["hasMore"]


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ArangoDB-Community/python-arango/pull/254

Instead of having a separate `retry` function, it becomes the default behavior of the cursor to always fetch the last batch (that is, only if the `allow_retry` option is specified in the AQL query).
This adjustment reduces the complexity of the API and makes it easier to use. Also, users may start benefiting directly from this change after upgrading to 3.11, without having to make any refactoring to their existing code. All that is needed now is to set `allow_retry=True` in `arango.aql.AQL.execute`

I have added a code block to the documentation to illustrate the usage.
