### PR TITLE
[BTS-1515] Pass PoolTimeout as argument

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -13,7 +13,7 @@ from arango.connection import (
 )
 from arango.database import StandardDatabase
 from arango.exceptions import ServerConnectionError
-from arango.http import DefaultHTTPClient, HTTPClient
+from arango.http import DEFAULT_REQUEST_TIMEOUT, DefaultHTTPClient, HTTPClient
 from arango.resolver import (
     HostResolver,
     RandomHostResolver,
@@ -58,7 +58,7 @@ class ArangoClient:
        not specified. The default value is 60.
        None: No timeout.
        int: Timeout value in seconds.
-    :type request_timeout: Any
+    :type request_timeout: int | float
     """
 
     def __init__(
@@ -70,7 +70,7 @@ class ArangoClient:
         serializer: Callable[..., str] = lambda x: dumps(x),
         deserializer: Callable[[str], Any] = lambda x: loads(x),
         verify_override: Union[bool, str, None] = None,
-        request_timeout: Any = 60,
+        request_timeout: Union[int, float] = DEFAULT_REQUEST_TIMEOUT,
     ) -> None:
         if isinstance(hosts, str):
             self._hosts = [host.strip("/") for host in hosts.split(",")]

--- a/arango/client.py
+++ b/arango/client.py
@@ -55,7 +55,7 @@ class ArangoClient:
     :type verify_override: Union[bool, str, None]
     :param request_timeout: This is the default request timeout (in seconds)
        for http requests issued by the client if the parameter http_client is
-       not secified. The default value is 60.
+       not specified. The default value is 60.
        None: No timeout.
        int: Timeout value in seconds.
     :type request_timeout: Any
@@ -88,11 +88,7 @@ class ArangoClient:
             self._host_resolver = RoundRobinHostResolver(host_count, resolver_max_tries)
 
         # Initializes the http client
-        self._http = http_client or DefaultHTTPClient()
-        # Sets the request timeout.
-        # This call can only happen AFTER initializing the http client.
-        if http_client is None:
-            self.request_timeout = request_timeout
+        self._http = http_client or DefaultHTTPClient(request_timeout=request_timeout)
 
         self._serializer = serializer
         self._deserializer = deserializer
@@ -137,12 +133,12 @@ class ArangoClient:
         :return: Request timeout.
         :rtype: Any
         """
-        return self._http.REQUEST_TIMEOUT  # type: ignore
+        return self._http.request_timeout  # type: ignore
 
     # Setter for request_timeout
     @request_timeout.setter
     def request_timeout(self, value: Any) -> None:
-        self._http.REQUEST_TIMEOUT = value  # type: ignore
+        self._http.request_timeout = value  # type: ignore
 
     def db(
         self,

--- a/arango/http.py
+++ b/arango/http.py
@@ -117,7 +117,7 @@ class DefaultHTTPClient(HTTPClient):
     :param retry_attempts: Number of retry attempts.
     :type retry_attempts: int
     :param backoff_factor: Backoff factor for retry attempts.
-    :type backoff_factor: int
+    :type backoff_factor: float
     :param pool_connections: The number of urllib3 connection pools to cache.
     :type pool_connections: int
     :param pool_maxsize: The maximum number of connections to save in the pool.
@@ -130,12 +130,12 @@ class DefaultHTTPClient(HTTPClient):
         self,
         request_timeout: int = 60,
         retry_attempts: int = 3,
-        backoff_factor: int = 1,
+        backoff_factor: float = 1.0,
         pool_connections: int = 10,
         pool_maxsize: int = 10,
         pool_timeout: Union[int, float, None] = DEFAULT_POOL_TIMEOUT,
     ) -> None:
-        self._request_timeout = request_timeout
+        self.request_timeout = request_timeout
         self._retry_attempts = retry_attempts
         self._backoff_factor = backoff_factor
         self._pool_connections = pool_connections
@@ -205,7 +205,7 @@ class DefaultHTTPClient(HTTPClient):
             data=data,
             headers=headers,
             auth=auth,
-            timeout=self._request_timeout,
+            timeout=self.request_timeout,
         )
         return Response(
             method=method,

--- a/arango/http.py
+++ b/arango/http.py
@@ -133,7 +133,7 @@ class DefaultHTTPClient(HTTPClient):
         backoff_factor: int = 1,
         pool_connections: int = 10,
         pool_maxsize: int = 10,
-        pool_timeout: Union[int, float] = 120,
+        pool_timeout: Union[int, float, None] = DEFAULT_POOL_TIMEOUT,
     ) -> None:
         self._request_timeout = request_timeout
         self._retry_attempts = retry_attempts

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -54,7 +54,7 @@ def test_client_attributes():
     assert isinstance(client._host_resolver, RandomHostResolver)
 
     client = ArangoClient(hosts=client_hosts, request_timeout=120)
-    assert client.request_timeout == client._http.REQUEST_TIMEOUT == 120
+    assert client.request_timeout == client._http.request_timeout == 120
 
 
 def test_client_good_connection(db, username, password):
@@ -90,6 +90,22 @@ def test_client_bad_connection(db, username, password, cluster):
     with pytest.raises(ServerConnectionError) as err:
         client.db(db.name, username, password, verify=True)
     assert "bad connection" in str(err.value)
+
+
+def test_client_http_client_attributes(db, username, password):
+    http_client = DefaultHTTPClient(
+        request_timeout=80,
+        retry_attempts=5,
+        backoff_factor=1.0,
+        pool_connections=16,
+        pool_maxsize=12,
+        pool_timeout=120,
+    )
+    client = ArangoClient(
+        hosts="http://127.0.0.1:8529", http_client=http_client, request_timeout=30
+    )
+    client.db(db.name, username, password, verify=True)
+    assert http_client.request_timeout == 80
 
 
 def test_client_custom_http_client(db, username, password):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,6 +106,7 @@ def test_client_http_client_attributes(db, username, password):
     )
     client.db(db.name, username, password, verify=True)
     assert http_client.request_timeout == 80
+    assert client.request_timeout == http_client.request_timeout
 
 
 def test_client_custom_http_client(db, username, password):


### PR DESCRIPTION
This PR makes the `DefaultHTTPClient` more flexible, adding the following new parameters:
- request_timeout: socket timeout in seconds for each individual connection
- pool_connections: the number of urllib3 connection pools to cache
- pool_maxsize: the maximum number of connections to save in the pool
- pool_timeout: if set, then the pool will be set to block=True, and requests will block for pool_timeout seconds and raise `EmptyPoolError` if no connection is available within the time period

The ones prefixed with *_pool* are all passed to the `PoolManager`. Note that these values cannot be changed once the HTTP client has been created.

The following constants were already used before, but are now configurable as parameters:
- request_timeout 
- retry_attempts
- backoff_factor

Note that `request_timeout` is mapped to the parameter with the same name of the HTTP client. Unlike the other parameters, this one can be changed.

The default values stay the same. If clients don't specify any parameters, nothing changes.

**Example**
```python
http_client = DefaultHTTPClient(
    request_timeout=80,
    retry_attempts=5,
    backoff_factor=1.0,
    pool_connections=16,
    pool_maxsize=12,
    pool_timeout=120,
)
client = ArangoClient(hosts="http://127.0.0.1:8529", http_client=http_client)
db = client.db(db.name, username, password, verify=True)
client.request_timeout = 100  # increase timeout for all requests
```