### PR TITLE
[DE-545] UTF-8 names

### DIFF
--- a/tests/static/cluster.conf
+++ b/tests/static/cluster.conf
@@ -8,4 +8,6 @@ jwt-secret = /tests/static/keyfile
 
 [args]
 all.database.password = passwd
+# Extended names can be used starting with 3.11
+# all.database.extended-names = true
 all.log.api-enabled = true

--- a/tests/static/single.conf
+++ b/tests/static/single.conf
@@ -8,3 +8,5 @@ jwt-secret = /tests/static/keyfile
 
 [args]
 all.database.password = passwd
+# Extended names can be used starting with 3.11
+# all.database.extended-names = true

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -254,5 +254,7 @@ def test_collection_utf8(db, db_version, special_collection_names):
         col = db.create_collection(name)
         assert col.name == name
         assert db.has_collection(name) is True
+        index_id = col.add_hash_index(fields=['foo'])['name']
+        assert index_id == col.indexes()[-1]['name']
         assert db.delete_collection(name) is True
         assert db.has_collection(name) is False

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -254,7 +254,7 @@ def test_collection_utf8(db, db_version, special_collection_names):
         col = db.create_collection(name)
         assert col.name == name
         assert db.has_collection(name) is True
-        index_id = col.add_hash_index(fields=['foo'])['name']
-        assert index_id == col.indexes()[-1]['name']
+        index_id = col.add_hash_index(fields=["foo"])["name"]
+        assert index_id == col.indexes()[-1]["name"]
         assert db.delete_collection(name) is True
         assert db.has_collection(name) is False

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,6 +1,7 @@
 import pytest
 from packaging import version
 
+from arango.client import ArangoClient
 from arango.collection import StandardCollection
 from arango.exceptions import (
     CollectionChecksumError,
@@ -16,8 +17,15 @@ from arango.exceptions import (
     CollectionStatisticsError,
     CollectionTruncateError,
     CollectionUnloadError,
+    DatabaseDeleteError,
 )
-from tests.helpers import assert_raises, extract, generate_col_name
+from tests.helpers import (
+    assert_raises,
+    extract,
+    generate_col_name,
+    generate_string,
+    generate_username,
+)
 
 
 def test_collection_attributes(db, col, username):
@@ -246,15 +254,69 @@ def special_collection_names(db):
             pass
 
 
+# Code duplication from `test_database.py`...
+@pytest.fixture
+def special_db_names(sys_db):
+    names = ["abc123", "maçã", "mötör", "😀", "ﻚﻠﺑ ﻞﻄﻴﻓ", "かわいい犬"]
+
+    yield names
+
+    for name in names:
+        try:
+            sys_db.delete_database(name)
+        except DatabaseDeleteError:
+            pass
+
+
 def test_collection_utf8(db, db_version, special_collection_names):
     if db_version < version.parse("3.11.0"):
         pytest.skip("UTF8 collection names require ArangoDB 3.11+")
 
     for name in special_collection_names:
-        col = db.create_collection(name)
-        assert col.name == name
-        assert db.has_collection(name) is True
-        index_id = col.add_hash_index(fields=["foo"])["name"]
-        assert index_id == col.indexes()[-1]["name"]
-        assert db.delete_collection(name) is True
-        assert db.has_collection(name) is False
+        create_and_delete_collection(db, name)
+
+
+# Not sure if this belongs in here or in `test_database.py`...
+def test_database_and_collection_utf8(
+    sys_db, db_version, special_collection_names, special_db_names
+):
+    if db_version < version.parse("3.11.0"):
+        pytest.skip("UTF8 collection names require ArangoDB 3.11+")
+
+    client = ArangoClient(hosts="http://127.0.0.1:8529")
+    for db_name in special_db_names:
+        username = generate_username()
+        password = generate_string()
+
+        assert sys_db.create_database(
+            name=db_name,
+            users=[
+                {
+                    "active": True,
+                    "username": username,
+                    "password": password,
+                }
+            ],
+        )
+
+        assert sys_db.has_database(db_name)
+
+        db = client.db(db_name, username, password, verify=True)
+
+        for col_name in special_collection_names:
+            create_and_delete_collection(db, col_name)
+
+        assert sys_db.delete_database(db_name)
+
+
+def create_and_delete_collection(db, name):
+    col = db.create_collection(name)
+    assert col.name == name
+    assert db.has_collection(name) is True
+
+    index_id = col.add_hash_index(fields=["foo"])["name"]
+    assert index_id == col.indexes()[-1]["name"]
+    assert col.delete_index(index_id) is True
+
+    assert db.delete_collection(name) is True
+    assert db.has_collection(name) is False


### PR DESCRIPTION
It is the responsibility of the server to enable extended names. The driver can send any UTF-8 string along with the request.
Therefore, this PR doesn't really add any new and exciting features. Instead, it adds two tests (one for databases and one for collections), making sure the driver can successfully forward UTF-8 names to the server.
Note that, in order to run the tests, the server has to be started with the `--database.extended-names` option. Unfortunately, this is only possible starting with 3.11 docker images, and we're currently using 3.10.9 for our GitHub actions. Nevertheless, I have added the parameter as a comment for now. I can confirm the tests have passed locally for versions >= 3.11.0.  