### PR TITLE
[DE-554] `serverId` query param (GET/PUT `/_admin/log/level`)

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -572,13 +572,22 @@ class Database(ApiGroup):
 
         return self._execute(request, response_handler)
 
-    def log_levels(self) -> Result[Json]:
+    def log_levels(self, server_id: Optional[str] = None) -> Result[Json]:
         """Return current logging levels.
 
+        :param server_id: Forward log level to a specific server. This makes it
+            easier to adjust the log levels in clusters because DB-Servers require
+            JWT authentication whereas Coordinators also support authentication
+            using usernames and passwords.
+        :type server_id: str
         :return: Current logging levels.
         :rtype: dict
         """
-        request = Request(method="get", endpoint="/_admin/log/level")
+        params: Params = {}
+        if server_id is not None:
+            params["serverId"] = server_id
+
+        request = Request(method="get", endpoint="/_admin/log/level", params=params)
 
         def response_handler(resp: Response) -> Json:
             if not resp.is_success:
@@ -588,7 +597,9 @@ class Database(ApiGroup):
 
         return self._execute(request, response_handler)
 
-    def set_log_levels(self, **kwargs: str) -> Result[Json]:
+    def set_log_levels(
+        self, server_id: Optional[str] = None, **kwargs: str
+    ) -> Result[Json]:
         """Set the logging levels.
 
         This method takes arbitrary keyword arguments where the keys are the
@@ -604,10 +615,21 @@ class Database(ApiGroup):
 
         Keys that are not valid logger names are ignored.
 
+        :param server_id: Forward log level to a specific server. This makes it
+            easier to adjust the log levels in clusters because DB-Servers require
+            JWT authentication whereas Coordinators also support authentication
+            using usernames and passwords.
+        :type server_id: str | None
         :return: New logging levels.
         :rtype: dict
         """
-        request = Request(method="put", endpoint="/_admin/log/level", data=kwargs)
+        params: Params = {}
+        if server_id is not None:
+            params["serverId"] = server_id
+
+        request = Request(
+            method="put", endpoint="/_admin/log/level", params=params, data=kwargs
+        )
 
         def response_handler(resp: Response) -> Json:
             if not resp.is_success:


### PR DESCRIPTION
Introduced in: `v3.10.2`

The `GET /_admin/log/level` and `PUT /_admin/log/level` endpoints support a new query parameter `serverId`, to forward log level get and set requests to a specific server.

This makes it easier to adjust the log levels in clusters because DB-Servers require JWT authentication whereas Coordinators also support authentication using usernames and passwords.


Introduced: https://github.com/arangodb/docs/pull/1209 
Documentation: https://www.arangodb.com/docs/devel/release-notes-api-changes310.html#log-level-api