### PR TITLE
[DE-566] geo_s2 analyzer test case

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -63,6 +63,7 @@ def test_analyzer_management(db, bad_db, cluster, enterprise, db_version):
     if enterprise and db_version >= version.parse("3.10.5"):
         analyzer_name = generate_analyzer_name()
         result = db.create_analyzer(analyzer_name, "geo_s2", {})
+        assert result["type"] == "geo_s2"
         assert result["features"] == []
         assert result["properties"] == {
             "options": {"maxCells": 20, "minLevel": 4, "maxLevel": 23},

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,3 +1,5 @@
+from packaging import version
+
 from arango.exceptions import (
     AnalyzerCreateError,
     AnalyzerDeleteError,
@@ -7,7 +9,7 @@ from arango.exceptions import (
 from tests.helpers import assert_raises, generate_analyzer_name
 
 
-def test_analyzer_management(db, bad_db, cluster):
+def test_analyzer_management(db, bad_db, cluster, enterprise, db_version):
     analyzer_name = generate_analyzer_name()
     full_analyzer_name = db.name + "::" + analyzer_name
     bad_analyzer_name = generate_analyzer_name()
@@ -56,3 +58,11 @@ def test_analyzer_management(db, bad_db, cluster):
 
     # Test delete missing analyzer with ignore_missing set to True
     assert db.delete_analyzer(analyzer_name, ignore_missing=True) is False
+
+    # Test create geo_s2 analyzer (EE only)
+    if enterprise and db_version >= version.parse("3.10.5"):
+        analyzer_name = generate_analyzer_name()
+        result = db.create_analyzer(analyzer_name, "geo_s2", {})
+        assert result["type"] == "geo_s2"
+        assert result["properties"]["format"] == "latLngDouble"
+        assert db.delete_analyzer(analyzer_name)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -63,6 +63,10 @@ def test_analyzer_management(db, bad_db, cluster, enterprise, db_version):
     if enterprise and db_version >= version.parse("3.10.5"):
         analyzer_name = generate_analyzer_name()
         result = db.create_analyzer(analyzer_name, "geo_s2", {})
-        assert result["type"] == "geo_s2"
-        assert result["properties"]["format"] == "latLngDouble"
+        assert result["features"] == []
+        assert result["properties"] == {
+            "options": {"maxCells": 20, "minLevel": 4, "maxLevel": 23},
+            "type": "shape",
+            "format": "latLngDouble",
+        }
         assert db.delete_analyzer(analyzer_name)


### PR DESCRIPTION
DE-566 seeks to introduce `geo_s2` analyzer creation support.

Given that the `database.create_analyzer` method accepts `analyzer_type` as a parameter, there is no feature implementation required.

Nevertheless a test case has been added to ensure `python-arango`'s support for `geo_s2` analyzer creation (on EE >=3.10.5 only)