### PR TITLE
Fix python-arango Client (de)serialization

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -22,6 +22,30 @@ from arango.resolver import (
 )
 
 
+def default_serializer(x: Any) -> str:
+    """
+    Default JSON serializer
+
+    :param x: A JSON data type object to serialize
+    :type x: Any
+    :return: The object serialized as a JSON string
+    :rtype: str
+    """
+    return dumps(x)
+
+
+def default_deserializer(x: str) -> Any:
+    """
+    Default JSON de-serializer
+
+    :param x: A JSON string to deserialize
+    :type x: str
+    :return: The de-serialized JSON object
+    :rtype: Any
+    """
+    return loads(x)
+
+
 class ArangoClient:
     """ArangoDB client.
 
@@ -67,8 +91,8 @@ class ArangoClient:
         host_resolver: str = "roundrobin",
         resolver_max_tries: Optional[int] = None,
         http_client: Optional[HTTPClient] = None,
-        serializer: Callable[..., str] = lambda x: dumps(x),
-        deserializer: Callable[[str], Any] = lambda x: loads(x),
+        serializer: Callable[..., str] = default_serializer,
+        deserializer: Callable[[str], Any] = default_deserializer,
         verify_override: Union[bool, str, None] = None,
         request_timeout: Union[int, float] = DEFAULT_REQUEST_TIMEOUT,
     ) -> None:

--- a/arango/http.py
+++ b/arango/http.py
@@ -84,6 +84,16 @@ class DefaultHTTPAdapter(HTTPAdapter):
     :type kwargs: Any
     """
 
+    __attrs__ = [
+        "max_retries",
+        "config",
+        "_connection_timeout",
+        "_pool_connections",
+        "_pool_maxsize",
+        "_pool_timeout",
+        "_pool_block",
+    ]
+
     def __init__(
         self,
         connection_timeout: Union[int, float] = DEFAULT_REQUEST_TIMEOUT,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import json
+import pickle
 from typing import Union
 
 import importlib_metadata
@@ -180,3 +181,10 @@ def test_client_override_validate() -> None:
     assert_verify("test", False, False)
     assert_verify("test", False, False)
     assert_verify("test", "foo", "foo")
+
+
+def test_can_serialize_deserialize_client() -> None:
+    client = ArangoClient(hosts="http://127.0.0.1:8529")
+    client_pstr = pickle.dumps(client)
+    client2 = pickle.loads(client_pstr)
+    assert len(client2._sessions) > 0


### PR DESCRIPTION
This PR allows a python-arango `ArangoClient` to be serialized and deserialized correctly using `pickle`. This is needed for usage in multi-process environments. 

To solve this, two named functions replace the `lambda` functions for JSON serialization and deserialization in the client constructor, and the `DefaultHTTPAdapter` now correctly overrides its `__attrs__` variable, including the latest timeout variables to support correct `__getstate__` and `__setstate__` calls.