### PR TITLE
Computed Values support for `/_api/collection/collection/properties`

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -306,6 +306,7 @@ class Collection(ApiGroup):
         schema: Optional[Json] = None,
         replication_factor: Optional[int] = None,
         write_concern: Optional[int] = None,
+        computed_values: Optional[List[Json]] = None
     ) -> Result[Json]:
         """Configure collection properties.
 
@@ -341,6 +342,8 @@ class Collection(ApiGroup):
             data["replicationFactor"] = replication_factor
         if write_concern is not None:
             data["writeConcern"] = write_concern
+        if computed_values is not None:
+            data["computedValues"] = computed_values
 
         request = Request(
             method="put",

--- a/arango/formatter.py
+++ b/arango/formatter.py
@@ -249,20 +249,9 @@ def format_collection(body: Json) -> Json:
         result["min_revision"] = body["minRevision"]
     if "schema" in body:
         result["schema"] = body["schema"]
+    if "computedValues" in body:
+        result["computedValues"] = body["computedValues"]
 
-    # New in 3.10
-    if body.get("computedValues") is not None:
-        result["computedValues"] = [
-            {
-                "name": cv["name"],
-                "expression": cv["expression"],
-                "overwrite": cv["overwrite"],
-                "computedOn": cv["computedOn"],
-                "keepNull": cv["keepNull"],
-                "failOnWarning": cv["failOnWarning"],
-            }
-            for cv in body["computedValues"]
-        ]
     if "internalValidatorType" in body:
         result["internal_validator_type"] = body["internalValidatorType"]
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -49,10 +49,26 @@ def test_collection_misc_methods(col, bad_col, cluster):
 
     # Test configure properties
     prev_sync = properties["sync"]
-    properties = col.configure(sync=not prev_sync, schema={})
+
+    computed_values = [
+        {
+            "name": "foo",
+            "expression": "RETURN 1",
+            "computeOn": ["insert", "update", "replace"],
+            "overwrite": True,
+            "failOnWarning": False,
+            "keepNull": True,
+        }
+    ]
+
+    properties = col.configure(
+        sync=not prev_sync, schema={}, computed_values=computed_values
+    )
+
     assert properties["name"] == col.name
     assert properties["system"] is False
     assert properties["sync"] is not prev_sync
+    assert properties["computedValues"] == computed_values
 
     # Test configure properties with bad collection
     with assert_raises(CollectionConfigureError) as err:
@@ -153,6 +169,17 @@ def test_collection_management(db, bad_db, cluster):
         "type": "json",
     }
 
+    computed_values = [
+        {
+            "name": "foo",
+            "expression": "RETURN 1",
+            "computeOn": ["insert", "update", "replace"],
+            "overwrite": True,
+            "failOnWarning": False,
+            "keepNull": True,
+        }
+    ]
+
     col = db.create_collection(
         name=col_name,
         sync=True,
@@ -172,6 +199,7 @@ def test_collection_management(db, bad_db, cluster):
         smart_join_attribute="test_attr",
         write_concern=1,
         schema=schema,
+        computedValues=computed_values,
     )
     assert db.has_collection(col_name) is True
 
@@ -181,6 +209,7 @@ def test_collection_management(db, bad_db, cluster):
     assert properties["name"] == col_name
     assert properties["sync"] is True
     assert properties["system"] is False
+    assert properties["computedValues"] == computed_values
 
     # Test create duplicate collection
     with assert_raises(CollectionCreateError) as err:


### PR DESCRIPTION
- Introduces a `computer_values` parameter for the `collection.configure` method
- Test cases for setting & fetching [computedValues](https://www.arangodb.com/docs/3.11/data-modeling-documents-computed-values.html)
- discussion required: rework `computerValues` logic in the `format.format_collection` method to support unspecified values in a computedValue dictionary 