### PR TITLE
Remove deprecated strict parameter from PoolManager

### DIFF
--- a/arango/http.py
+++ b/arango/http.py
@@ -117,7 +117,6 @@ class DefaultHTTPAdapter(HTTPAdapter):
             dict(
                 num_pools=connections,
                 maxsize=maxsize,
-                strict=True,
                 timeout=self._connection_timeout,
             )
         )


### PR DESCRIPTION
Resolve warning raised by urllib3:
> DeprecationWarning: The 'strict' parameter is no longer needed on Python 3+.
> This will raise an error in urllib3 v2.1.0.

Relevant PRs/issues:
- https://github.com/psf/requests/pull/6434
- https://github.com/urllib3/urllib3/issues/2263