### PR TITLE
[DE-542] Adding support for shards retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+main
+-----
+
+* [DE-542] Added `shards()` method to `Collection`
+
 7.6.0
-----
+-----
 
 * [DE-562] Index Cache Refilling by @apetenchea in https://github.com/ArangoDB-Community/python-arango/pull/259
 

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -258,6 +258,10 @@ class CollectionConfigureError(ArangoServerError):
     """Failed to configure collection properties."""
 
 
+class CollectionShardsError(ArangoServerError):
+    """Failed to retrieve collection shards."""
+
+
 class CollectionStatisticsError(ArangoServerError):
     """Failed to retrieve collection statistics."""
 

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "7.5.8"
+    driver_version = "7.6.0"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/tester.sh
+++ b/tester.sh
@@ -21,9 +21,9 @@ if [[ "$tests" != "all" && "$tests" != "community" && "$tests" != "enterprise" ]
     exit 1
 fi
 
-# 3.11.1
+# 3.11.2
 # 3.10.9
-# 3.9.9
+# 3.9.11
 version="${3:-3.11.1}"
 
 if [[ -n "$4" && "$4" != "notest" ]]; then

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -204,6 +204,13 @@ def test_collection_management(db, bad_db, cluster):
     )
     assert db.has_collection(col_name) is True
 
+    if cluster:
+        for details in (False, True):
+            shards = col.shards(details=details)
+            assert shards["name"] == col_name
+            assert shards["system"] is False
+            assert len(shards["shards"]) == 2
+
     properties = col.properties()
     assert "key_options" in properties
     assert properties["schema"] == schema

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -56,7 +56,7 @@ def test_database_attributes(db, username):
     assert isinstance(db.wal, WAL)
 
 
-def test_database_misc_methods(sys_db, db, bad_db):
+def test_database_misc_methods(sys_db, db, bad_db, cluster):
     # Test get properties
     properties = db.properties()
     assert "id" in properties
@@ -202,10 +202,6 @@ def test_database_misc_methods(sys_db, db, bad_db):
     # Test get log levels
     assert isinstance(sys_db.log_levels(), dict)
 
-    # Test get log levels (with server_id)
-    server_id = sys_db.replication.server_id()
-    assert isinstance(sys_db.log_levels(server_id), dict)
-
     # Test get log levels with bad database
     with assert_raises(ServerLogLevelError) as err:
         bad_db.log_levels()
@@ -219,12 +215,17 @@ def test_database_misc_methods(sys_db, db, bad_db):
     for key, value in sys_db.log_levels().items():
         assert result[key] == value
 
-    # Test set log levels (with server_id)
-    result = sys_db.set_log_levels(server_id, **new_levels)
-    for key, value in new_levels.items():
-        assert result[key] == value
-    for key, value in sys_db.log_levels(server_id).items():
-        assert result[key] == value
+    if cluster:
+        # Test get log levels (with server_id)
+        server_id = sys_db.cluster.server_id()
+        assert isinstance(sys_db.log_levels(server_id), dict)
+
+        # Test set log levels (with server_id)
+        result = sys_db.set_log_levels(server_id, **new_levels)
+        for key, value in new_levels.items():
+            assert result[key] == value
+        for key, value in sys_db.log_levels(server_id).items():
+            assert result[key] == value
 
     # Test set log levels with bad database
     with assert_raises(ServerLogLevelSetError):


### PR DESCRIPTION
**Main changes**

- Adding `shards()` method to `Collection`, reflecting [/_api/collection/{collection-name}/shards](https://www.arangodb.com/docs/stable/http/collection.html#get-the-shard-ids-of-a-collection). It will be available only in a cluster setup.

**Minor patches**
- Adding docstring for `computed_values`
- Updating driver version in request header
- Fixing `test_database_misc_methods`. Getting and setting log levels for individual servers is available only in a cluster.
