### PR TITLE
[DE-584] Refactor Deprecated `/_api/simple` methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+main
+-----
+
+* [DE-584] Refactor deprecated `/_api/simple` methods
+
 7.6.0
-----
+-----
 
 * [DE-562] Index Cache Refilling by @apetenchea in https://github.com/ArangoDB-Community/python-arango/pull/259
 

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -952,6 +952,9 @@ class Collection(ApiGroup):
             geo_index = self.get_index(f"{self.name}/{index}")
             assert isinstance(geo_index, dict)
 
+            if geo_index["type"] != "geo":
+                raise ValueError("**index** must point to a Geo Index")
+
             geo_index_fields = geo_index["fields"]
 
             if len(geo_index_fields) == 1:

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -981,7 +981,7 @@ class Collection(ApiGroup):
                 return f"doc.{index_field[0]}"
             elif len(index_field) == 2:
                 return f"[doc.{index_field[0]}, doc.{index_field[1]}]"
-            else:
+            else:  # pragma: no cover
                 m = "**index** must be a geo index with 1 or 2 fields"
                 raise ValueError(m)
 

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -949,7 +949,7 @@ class Collection(ApiGroup):
         # Initial assumption that attribute names are "latitude" and "longitude"
         geo_str = "[doc.longitude, doc.latitude]"
         if index is not None:
-            geo_index = self.get_index(f"{self.name}/{index}")
+            geo_index = self.get_index(index)
             assert isinstance(geo_index, dict)
 
             if geo_index["type"] != "geo":
@@ -1153,7 +1153,7 @@ class Collection(ApiGroup):
         """
         request = Request(
             method="get",
-            endpoint=f"/_api/index/{id}",
+            endpoint=f"/_api/index/{self.name}/{id}",
         )
 
         def response_handler(resp: Response) -> Json:

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -560,6 +560,10 @@ class IndexGetError(ArangoServerError):
     """Failed to retrieve collection index."""
 
 
+class IndexMissingError(ArangoClientError):
+    """Failed to find collection index."""
+
+
 class IndexDeleteError(ArangoServerError):
     """Failed to delete collection index."""
 

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -556,6 +556,10 @@ class IndexCreateError(ArangoServerError):
     """Failed to create collection index."""
 
 
+class IndexGetError(ArangoServerError):
+    """Failed to retrieve collection index."""
+
+
 class IndexDeleteError(ArangoServerError):
     """Failed to delete collection index."""
 

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -66,7 +66,7 @@ def is_none_or_int(obj: Any) -> bool:
     """Check if obj is None or an integer.
 
     :param obj: Object to check.
-    :type obj: object
+    :type obj: Any
     :return: True if object is None or an integer.
     :rtype: bool
     """
@@ -77,11 +77,22 @@ def is_none_or_str(obj: Any) -> bool:
     """Check if obj is None or a string.
 
     :param obj: Object to check.
-    :type obj: object
+    :type obj: Any
     :return: True if object is None or a string.
     :rtype: bool
     """
     return obj is None or isinstance(obj, str)
+
+
+def is_none_or_bool(obj: Any) -> bool:
+    """Check if obj is None or a bool.
+
+    :param obj: Object to check.
+    :type obj: Any
+    :return: True if object is None or a bool.
+    :rtype: bool
+    """
+    return obj is None or isinstance(obj, bool)
 
 
 def get_batches(elements: Sequence[Json], batch_size: int) -> Iterator[Sequence[Json]]:
@@ -95,3 +106,24 @@ def get_batches(elements: Sequence[Json], batch_size: int) -> Iterator[Sequence[
     """
     for index in range(0, len(elements), batch_size):
         yield elements[index : index + batch_size]
+
+
+def build_filter_conditions(filters: Json) -> str:
+    """Build a filter condition for an AQL query.
+
+    :param filters: Document filters.
+    :type filters: Dict[str, Any]
+    :return: The complete AQL filter condition.
+    :rtype: str
+    """
+    if not filters:
+        return ""
+
+    def format_condition(key: str, value: Any) -> str:
+        if isinstance(value, str):
+            return f'doc.{key} == "{value}"'
+
+        return f"doc.{key} == {value}"
+
+    conditions = [format_condition(k, v) for k, v in filters.items()]
+    return "FILTER " + " AND ".join(conditions)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1434,11 +1434,11 @@ def test_document_find_in_box(col, bad_col, geo, cluster):
             longitude1=0,
             latitude2=6,
             longitude2=3,
-            index='abc',
+            index="abc",
         )
 
     # Test find_in_box with non-geo index
-    non_geo = col.add_hash_index(fields=['loc'])
+    non_geo = col.add_hash_index(fields=["loc"])
     with assert_raises(ValueError) as err:
         col.find_in_box(
             latitude1=0,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -12,6 +12,7 @@ from arango.exceptions import (
     DocumentReplaceError,
     DocumentRevisionError,
     DocumentUpdateError,
+    IndexGetError,
 )
 from tests.helpers import (
     assert_raises,
@@ -1164,6 +1165,20 @@ def test_document_find(col, bad_col, docs):
     assert len(found) == 1
     assert found[0]["_key"] == "2"
 
+    # Test find with text value
+    found = list(col.find({"text": "foo"}))
+    assert len(found) == 3
+
+    # Test find with list value
+    found = list(col.find({"loc": [1, 1]}))
+    assert len(found) == 1
+    assert found[0]["_key"] == "1"
+
+    # Test find with multiple conditions
+    found = list(col.find({"val": 2, "text": "foo"}))
+    assert len(found) == 1
+    assert found[0]["_key"] == "2"
+
     # Test find (multiple matches) with default options
     col.update_match({"val": 2}, {"val": 1})
     found = list(col.find({"val": 1}))
@@ -1364,7 +1379,7 @@ def test_document_find_in_box(col, bad_col, geo, cluster):
     result = col.find_in_box(
         latitude1=0, longitude1=0, latitude2=6, longitude2=3, limit=0, index=geo["id"]
     )
-    assert clean_doc(result) == [doc1, doc3]
+    assert clean_doc(result) == []
 
     # Test find_in_box with limit of 1
     result = col.find_in_box(
@@ -1373,12 +1388,13 @@ def test_document_find_in_box(col, bad_col, geo, cluster):
         latitude2=6,
         longitude2=3,
         limit=1,
+        index=geo["id"],
     )
     assert clean_doc(result) == [doc3]
 
     # Test find_in_box with limit of 4
     result = col.find_in_box(
-        latitude1=0, longitude1=0, latitude2=10, longitude2=10, limit=4
+        latitude1=0, longitude1=0, latitude2=10, longitude2=10, limit=4, index=geo["id"]
     )
     assert clean_doc(result) == [doc1, doc2, doc3, doc4]
 
@@ -1390,6 +1406,7 @@ def test_document_find_in_box(col, bad_col, geo, cluster):
             latitude2=6,
             longitude2=3,
             skip=-1,
+            index=geo["id"],
         )
     assert "skip must be a non-negative int" == str(err.value)
 
@@ -1400,22 +1417,24 @@ def test_document_find_in_box(col, bad_col, geo, cluster):
         latitude2=6,
         longitude2=3,
         skip=1,
+        index=geo["id"],
     )
     assert clean_doc(result) in [[doc1], [doc3]]
 
     # Test find_in_box with skip 3
     result = col.find_in_box(
-        latitude1=0, longitude1=0, latitude2=10, longitude2=10, skip=3
+        latitude1=0, longitude1=0, latitude2=10, longitude2=10, skip=3, index=geo["id"]
     )
     assert clean_doc(result) in [[doc1], [doc2], [doc3], [doc4]]
 
     # Test find_in_box with bad collection
-    with assert_raises(DocumentGetError) as err:
+    with assert_raises(IndexGetError) as err:
         bad_col.find_in_box(
             latitude1=0,
             longitude1=0,
             latitude2=6,
             longitude2=3,
+            index=geo["id"],
         )
     assert err.value.error_code in {11, 1228}
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1427,6 +1427,27 @@ def test_document_find_in_box(col, bad_col, geo, cluster):
     )
     assert clean_doc(result) in [[doc1], [doc2], [doc3], [doc4]]
 
+    # Test find_in_box with non-existing index
+    with assert_raises(IndexGetError) as err:
+        col.find_in_box(
+            latitude1=0,
+            longitude1=0,
+            latitude2=6,
+            longitude2=3,
+            index='abc',
+        )
+
+    # Test find_in_box with non-geo index
+    non_geo = col.add_hash_index(fields=['loc'])
+    with assert_raises(ValueError) as err:
+        col.find_in_box(
+            latitude1=0,
+            longitude1=0,
+            latitude2=6,
+            longitude2=3,
+            index=non_geo["id"],
+        )
+
     # Test find_in_box with bad collection
     with assert_raises(IndexGetError) as err:
         bad_col.find_in_box(

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1433,7 +1433,7 @@ def test_document_find_in_box(db, col, bad_col, geo, cluster):
     assert clean_doc(result) in [[doc1], [doc2], [doc3], [doc4]]
 
     # Test find_in_box with missing index in collection
-    empty_col = db.create_collection("empty_collection")
+    empty_col = db.create_collection(generate_col_name())
     with assert_raises(IndexMissingError) as err:
         empty_col.find_in_box(
             latitude1=0,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -4,6 +4,7 @@ from packaging import version
 from arango.exceptions import (
     IndexCreateError,
     IndexDeleteError,
+    IndexGetError,
     IndexListError,
     IndexLoadError,
 )
@@ -24,6 +25,16 @@ def test_list_indexes(icol, bad_col):
     with assert_raises(IndexListError) as err:
         bad_col.indexes()
     assert err.value.error_code in {11, 1228}
+
+
+def test_get_index(icol, bad_col):
+    indexes = icol.indexes()
+    for index in indexes:
+        assert index == icol.get_index(f"{icol.name}/{index['id']}")
+
+    with assert_raises(IndexGetError) as err:
+        icol.get_index("bad_index")
+    assert err.value.error_code == 400
 
 
 def test_add_hash_index(icol):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -30,11 +30,20 @@ def test_list_indexes(icol, bad_col):
 def test_get_index(icol, bad_col):
     indexes = icol.indexes()
     for index in indexes:
-        assert index == icol.get_index(f"{icol.name}/{index['id']}")
+        retrieved_index = icol.get_index(index["id"])
+        assert retrieved_index["id"] == index["id"]
+        assert retrieved_index["name"] == index["name"]
+        assert retrieved_index["type"] == index["type"]
+        assert retrieved_index["fields"] == index["fields"]
+        assert retrieved_index["sparse"] == index["sparse"]
+        assert retrieved_index["unique"] == index["unique"]
+        # TODO: Revisit
+        # assert retrieved_index["selectivity"] == index["selectivity"]
 
     with assert_raises(IndexGetError) as err:
         icol.get_index("bad_index")
-    assert err.value.error_code == 400
+
+    assert err.value.error_code == 1212
 
 
 def test_add_hash_index(icol):


### PR DESCRIPTION
**Main changes**

- Re-implements the following methods via AQL:
    - `collection.ids`
    -  `collection.keys`
    -  `collection.all`
    -  `collection.find`
    -  `collection.find_in_box` (requesting feedback / second opinion on implementation)
    -  `collection.random`
    -  `collection.update_match`
    -  `collection.replace_match`
    -  `collection.delete_match`

- Implements the `collection.get_index` method (`GET /_api/index/{id}`) as it was previously missing

**Miscellaneous changes**

- New utility function: `build_filter_conditions` (now used in the filter-based simple methods)
- Add `allow_dirty_read` parameter to the reworked simple methods given that they are now implemented using the `_api/cursor` endpoint
- docstring cleanup
- test case cleanup