### PR TITLE
fix: `build_filter_conditions` utils method

### DIFF
--- a/arango/utils.py
+++ b/arango/utils.py
@@ -6,7 +6,7 @@ __all__ = [
     "is_none_or_str",
 ]
 
-# import json
+import json
 import logging
 from contextlib import contextmanager
 from typing import Any, Iterator, Sequence, Union
@@ -120,12 +120,5 @@ def build_filter_conditions(filters: Json) -> str:
     if not filters:
         return ""
 
-    def format_condition(key: str, value: Any) -> str:
-        if isinstance(value, str):
-            return f'doc.{key} == "{value}"'
-
-        return f"doc.{key} == {value}"
-
-    # conditions = [f"doc.{k} == {json.dumps(v)}" for k, v in filters.items()]
-    conditions = [format_condition(k, v) for k, v in filters.items()]
+    conditions = [f"doc.{k} == {json.dumps(v)}" for k, v in filters.items()]
     return "FILTER " + " AND ".join(conditions)

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -6,6 +6,7 @@ __all__ = [
     "is_none_or_str",
 ]
 
+# import json
 import logging
 from contextlib import contextmanager
 from typing import Any, Iterator, Sequence, Union
@@ -125,5 +126,6 @@ def build_filter_conditions(filters: Json) -> str:
 
         return f"doc.{key} == {value}"
 
+    # conditions = [f"doc.{k} == {json.dumps(v)}" for k, v in filters.items()]
     conditions = [format_condition(k, v) for k, v in filters.items()]
     return "FILTER " + " AND ".join(conditions)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1175,6 +1175,12 @@ def test_document_find(col, bad_col, docs):
     assert len(found) == 1
     assert found[0]["_key"] == "1"
 
+    # Test find with dict value with None
+    data = {"dict": {"foo": "bar", "foo_2": None}}
+    col.insert(data)
+    found = list(col.find(data))
+    assert len(found) == 1
+
     # Test find with multiple conditions
     found = list(col.find({"val": 2, "text": "foo"}))
     assert len(found) == 1


### PR DESCRIPTION
The current implementation of `arango.utils.build_filter_conditions()` does not support filtering by `None` values (see the [test failures ](https://github.com/ArangoDB-Community/python-arango/actions/runs/6029808907/job/16360196835?pr=277)triggered by [75d7d7a](https://github.com/ArangoDB-Community/python-arango/pull/277/commits/75d7d7ab97151a996d80a7b8fe812d2ebbefe2cd))

This method is being used across many of the "simple" methods as of #275 

A simple fix is to rely on `json.dumps` to serialize the arbitrary values into a JSON formatted string