### PR TITLE
[DE-664] Deprecating Batch API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,33 @@
 main
 -----
 
+* Refactoring `BatchDatabase` API
+
+  - The batch API is deprecated since ArangoDB 3.8.0 and will be removed in a future version.
+  - The `BatchDatabase` is still available, but it now uses a `TreadPoolExecutor` internally.
+  - For backwards compatibility, the `BatchDatabase` uses only one worker thread, essentially
+    sending the requests sequentially. Feel free to set the `max_workers` parameter to a higher
+    value if you want to use multiple threads, but be aware that the requests will be sent in
+    parallel, which may cause problems if you are using transactions.
+  - To discourage the use of this API, we now issue a warning when the `BatchDatabase` is used.
+
+  Note that `{"foo": "bar"}` may be inserted after `{"foo": "baz"}` in the following example:
+  ```python
+  with db.begin_batch_execution(max_workers=2) as batch_db:
+      job1 = batch_db.collection.insert({"foo": "bar"})
+      job2 = batch_db.collection.insert({"foo": "baz"})
+  ```
+
+7.6.2
+-----
+
+* Fix: build_filter_conditions utils method
+
 7.6.1
 -----
 
 * [DE-542] Added `shards()` method to `Collection` by @apetenchea in https://github.com/ArangoDB-Community/python-arango/pull/274
-* [DE-584] Refactor deprecated `/_api/simple` methods by @aMahanna in https://github.com/ArangoDB-Community/python-arango/pull/268
+* [DE-584] Refactor deprecated `/_api/simple` methods by @aMahanna in https://github.com/ArangoDB-Community/python-arango/pull/275
 * Added `raise_on_document_error` parameter to `Collection.update_many()` by @aMahanna in https://github.com/ArangoDB-Community/python-arango/pull/273
 * Added `computed_values` parameter to `Collection.onfigure()` by @aMahanna in https://github.com/ArangoDB-Community/python-arango/pull/268
 * Various bug fixes

--- a/arango/formatter.py
+++ b/arango/formatter.py
@@ -157,6 +157,8 @@ def format_database(body: Json) -> Json:
         result["replication_factor"] = body["replicationFactor"]
     if "writeConcern" in body:
         result["write_concern"] = body["writeConcern"]
+    if "replicationVersion" in body:
+        result["replication_version"] = body["replicationVersion"]
 
     return verify_format(body, result)
 

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "7.6.1"
+    driver_version = "7.6.2"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/docs/batch.rst
+++ b/docs/batch.rst
@@ -1,9 +1,30 @@
 Batch API Execution
 -------------------
+.. warning::
 
-In **batch API executions**, requests to ArangoDB server are stored in client-side
-in-memory queue, and committed together in a single HTTP call. After the commit,
-results can be retrieved later from :ref:`BatchJob` objects.
+    The batch request API is deprecated since ArangoDB 3.8.0.
+    We discourage its use, as it will be removed in a future release.
+    It is already slow and seems to regularly create weird errors when
+    used with recent versions of ArangoDB.
+
+    The driver functionality has been refactored to no longer use the batch API,
+    but a `ThreadPoolExecutor` instead. For backwards compatibility,
+    `max_workers` is set to 1 by default, but can be increased to speed up
+    batch operations. Essentially, the batch API can now be used to send
+    multiple requests in parallel, but not to send multiple requests in a
+    single HTTP call. Note that sending multiple requests in parallel may
+    cause conflicts on the servers side (for example, requests that modify the same document).
+
+    To send multiple documents at once to an ArangoDB instance,
+    please use any of :class:`arango.collection.Collection` methods
+    that accept a list of documents as input, such as:
+
+    * :func:`~arango.collection.Collection.insert_many`
+    * :func:`~arango.collection.Collection.update_many`
+    * :func:`~arango.collection.Collection.replace_many`
+    * :func:`~arango.collection.Collection.delete_many`
+
+After the commit, results can be retrieved later from :ref:`BatchJob` objects.
 
 **Example:**
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ import jwt
 import pytest
 
 from arango.cursor import Cursor
-from arango.exceptions import AsyncExecuteError, BatchExecuteError, TransactionInitError
+from arango.exceptions import AsyncExecuteError, TransactionInitError
 
 
 def generate_db_name():
@@ -180,6 +180,4 @@ def assert_raises(*exc):
     :param exc: Expected exception(s).
     :type: exc
     """
-    return pytest.raises(
-        exc + (AsyncExecuteError, BatchExecuteError, TransactionInitError)
-    )
+    return pytest.raises(exc + (AsyncExecuteError, TransactionInitError))


### PR DESCRIPTION
https://www.arangodb.com/docs/stable/http/batch-request.html
 
 - The batch API is deprecated since ArangoDB 3.8.0 and will be removed in a future version.
  - The `BatchDatabase` is still available, but it now uses a `TreadPoolExecutor` internally.
  - For backwards compatibility, the `BatchDatabase` uses only one worker thread, essentially sending the requests sequentially. Feel free to set the `max_workers` parameter to a higher value if you want to use multiple threads, but be aware that the requests will be sent in parallel, which may cause problems if you are using transactions.
  - To discourage the use of this API, we now issue a warning when the `BatchDatabase` is used. This warning may be disabled by the user.

  Note that `{"foo": "bar"}` may be inserted after `{"foo": "baz"}` in the following example:
  ```python
  with db.begin_batch_execution(max_workers=2) as batch_db:
      job1 = batch_db.collection.insert({"foo": "bar"})
      job2 = batch_db.collection.insert({"foo": "baz"})
  ```

Documentation has been updated accordingly.
