### PR TITLE
[DE-670]: `GET /_api/database/user`

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -761,13 +761,30 @@ class Database(ApiGroup):
     #######################
 
     def databases(self) -> Result[List[str]]:
-        """Return the names all databases.
+        """Return the names of all databases.
 
         :return: Database names.
         :rtype: [str]
         :raise arango.exceptions.DatabaseListError: If retrieval fails.
         """
         request = Request(method="get", endpoint="/_api/database")
+
+        def response_handler(resp: Response) -> List[str]:
+            if not resp.is_success:
+                raise DatabaseListError(resp, request)
+            result: List[str] = resp.body["result"]
+            return result
+
+        return self._execute(request, response_handler)
+
+    def databases_accessible_to_user(self) -> Result[List[str]]:
+        """Return the names of all databases accessible by the user.
+
+        :return: Database names accesible by the current user.
+        :rtype: List[str]
+        :raise arango.exceptions.DatabaseListError: If retrieval fails.
+        """
+        request = Request(method="get", endpoint="/_api/database/user")
 
         def response_handler(resp: Response) -> List[str]:
             if not resp.is_success:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -246,6 +246,12 @@ def test_database_management(db, sys_db, bad_db):
     # Test list databases
     result = sys_db.databases()
     assert "_system" in result
+    assert db.name in result
+
+    # Test list databases accesible to root user
+    result = sys_db.databases_accessible_to_user()
+    assert "_system" in result
+    assert db.name in result
 
     # Test list databases accessible to user
     result = db.databases_accessible_to_user()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -247,9 +247,17 @@ def test_database_management(db, sys_db, bad_db):
     result = sys_db.databases()
     assert "_system" in result
 
+    # Test list databases accessible to user
+    result = db.databases_accessible_to_user()
+    assert result == [db.name]
+
     # Test list databases with bad database
     with assert_raises(DatabaseListError):
         bad_db.databases()
+
+    # Test list accessible databases with bad database
+    with assert_raises(DatabaseListError):
+        bad_db.databases_accessible_to_user()
 
     # Test create database
     db_name = generate_db_name()


### PR DESCRIPTION
- Introduces `databases_accesible_to_user()` to return the list of databases currently accessible to the user