### PR TITLE
[DE-668]: `GET /_api/view/{view_name}`

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -2132,13 +2132,29 @@ class Database(ApiGroup):
         return self._execute(request, response_handler)
 
     def view(self, name: str) -> Result[Json]:
-        """Return view details.
+        """Return the properties of a View.
 
-        :return: View details.
+        :return: The View properties.
         :rtype: dict
         :raise arango.exceptions.ViewGetError: If retrieval fails.
         """
         request = Request(method="get", endpoint=f"/_api/view/{name}/properties")
+
+        def response_handler(resp: Response) -> Json:
+            if resp.is_success:
+                return format_view(resp.body)
+            raise ViewGetError(resp, request)
+
+        return self._execute(request, response_handler)
+
+    def view_info(self, name: str) -> Result[Json]:
+        """Return the id, name and type of a View.
+
+        :return: Some View information.
+        :rtype: dict
+        :raise arango.exceptions.ViewGetError: If retrieval fails.
+        """
+        request = Request(method="get", endpoint=f"/_api/view/{name}")
 
         def response_handler(resp: Response) -> Json:
             if resp.is_success:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -49,16 +49,26 @@ def test_view_management(db, bad_db, col, cluster):
         bad_db.views()
     assert err.value.error_code in {11, 1228}
 
-    # Test get view
+    # Test get view (properties)
     view = db.view(view_name)
     assert view["id"] == view_id
     assert view["name"] == view_name
     assert view["type"] == view_type
     assert view["consolidation_interval_msec"] == 50000
 
+    # Test get view (info)
+    view_info = db.view_info(view_name)
+    assert view_info["id"] == view_id
+    assert view_info["name"] == view_name
+    assert view_info["type"] == view_type
+
     # Test get missing view
     with assert_raises(ViewGetError) as err:
         db.view(bad_view_name)
+    assert err.value.error_code == 1203
+
+    with assert_raises(ViewGetError) as err:
+        db.view_info(bad_view_name)
     assert err.value.error_code == 1203
 
     # Test update view


### PR DESCRIPTION
- Introduces `view_info()` to retrieve basic information about a View. Not to be confused with the existing `view()` method, which returns the entire properties of a View