### PR TITLE
[DE-671]: `GET + PUT /_api/admin/license`

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -43,6 +43,8 @@ from arango.exceptions import (
     ServerEchoError,
     ServerEncryptionError,
     ServerEngineError,
+    ServerLicenseGetError,
+    ServerLicenseSetError,
     ServerLogLevelError,
     ServerLogLevelSetError,
     ServerMetricsError,
@@ -345,6 +347,54 @@ class Database(ApiGroup):
                 result: Json = resp.body["details"]
                 return result
             raise ServerDetailsError(resp, request)
+
+        return self._execute(request, response_handler)
+
+    def license(self) -> Result[Json]:
+        """View the license information and status of an
+        Enterprise Edition instance. Can be called on
+        single servers, Coordinators, and DB-Servers.
+
+        :return: Server license.
+        :rtype: dict
+        :raise arango.exceptions.ServerLicenseGetError: If retrieval fails.
+        """
+        request = Request(method="get", endpoint="/_admin/license")
+
+        def response_handler(resp: Response) -> Json:
+            if resp.is_success:
+                result: Json = resp.body
+                return result
+            raise ServerLicenseGetError(resp, request)
+
+        return self._execute(request, response_handler)
+
+    def set_license(self, license: str, force: bool = False) -> Result[Json]:
+        """Set a new license for an Enterprise Edition
+        instance. Can be called on single servers, Coordinators,
+        and DB-Servers.
+
+        :param license: The Base64-encoded license string.
+        :type license: str
+        :param force: If set to True, the new license will be set even if
+            it expires sooner than the current license.
+        :type force: bool
+        :return: Server license.
+        :rtype: dict
+        :raise arango.exceptions.ServerLicenseError: If retrieval fails.
+        """
+        request = Request(
+            method="put",
+            endpoint="/_admin/license",
+            params={"force": force},
+            data=license,
+        )
+
+        def response_handler(resp: Response) -> Json:
+            if resp.is_success:
+                result: Json = resp.body
+                return result
+            raise ServerLicenseSetError(resp, request)
 
         return self._execute(request, response_handler)
 

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -614,6 +614,14 @@ class ServerDetailsError(ArangoServerError):
     """Failed to retrieve server details."""
 
 
+class ServerLicenseGetError(ArangoServerError):
+    """Failed to retrieve server license."""
+
+
+class ServerLicenseSetError(ArangoServerError):
+    """Failed to set server license."""
+
+
 class ServerStatusError(ArangoServerError):
     """Failed to retrieve server status."""
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -319,3 +319,20 @@ def test_database_utf8(sys_db, db_version, special_db_names):
         assert sys_db.create_database(name)
         assert sys_db.has_database(name)
         assert sys_db.delete_database(name)
+
+
+def test_license(sys_db, db, enterprise):
+    license = sys_db.license()
+    assert isinstance(license, dict)
+
+    if enterprise:
+        assert set(license.keys()) == {
+            "upgrading",
+            "features",
+            "hash",
+            "license",
+            "version",
+            "status",
+        }
+    else:
+        assert license == {"license": "none"}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -20,6 +20,7 @@ from arango.exceptions import (
     ServerDetailsError,
     ServerEchoError,
     ServerEngineError,
+    ServerLicenseSetError,
     ServerLogLevelError,
     ServerLogLevelSetError,
     ServerMetricsError,
@@ -321,7 +322,7 @@ def test_database_utf8(sys_db, db_version, special_db_names):
         assert sys_db.delete_database(name)
 
 
-def test_license(sys_db, db, enterprise):
+def test_license(sys_db, enterprise):
     license = sys_db.license()
     assert isinstance(license, dict)
 
@@ -336,3 +337,5 @@ def test_license(sys_db, db, enterprise):
         }
     else:
         assert license == {"license": "none"}
+        with pytest.raises(ServerLicenseSetError):
+            sys_db.set_license("abc")


### PR DESCRIPTION
* Introduces `license()` and `set_license()` to get & set the license of an ArangoDB EE Instance