### PR TITLE
[DE-666] Cluster Rebalance

### DIFF
--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -975,6 +975,10 @@ class ClusterServerCountError(ArangoServerError):
     """Failed to retrieve cluster server count."""
 
 
+class ClusterRebalanceError(ArangoServerError):
+    """Failed to execute cluster re-balancing operation (load/set)."""
+
+
 ##################
 # JWT Exceptions #
 ##################

--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -91,4 +91,7 @@ Below is an example on how to manage clusters using python-arango.
     cluster.toggle_maintenance_mode('on')
     cluster.toggle_maintenance_mode('off')
 
+    # Rebalance the distribution of shards.
+    cluster.rebalance()
+
 See :ref:`ArangoClient` and :ref:`Cluster` for API specification.

--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -91,7 +91,7 @@ Below is an example on how to manage clusters using python-arango.
     cluster.toggle_maintenance_mode('on')
     cluster.toggle_maintenance_mode('off')
 
-    # Rebalance the distribution of shards.
+    # Rebalance the distribution of shards. Available with ArangoDB 3.10+.
     cluster.rebalance()
 
 See :ref:`ArangoClient` and :ref:`Cluster` for API specification.


### PR DESCRIPTION
This PR adds the following functionality to the `Cluster` class:
- **calculate_imbalance** (GET /_admin/cluster/rebalance) - used for getting the current cluster imbalance
- **rebalance** (PUT /_admin/cluster/rebalance) - used for rebalancing the shard distribution (calculates and then executes a rebalancing plan)
- **calculate_rebalance_plan** (POST /_admin/cluster/rebalance) - calculates (but does not execute) a rebalancing plan
- **execute_rebalancing_plan** (POST /_admin/cluster/rebalance/execute) - executes an already calculated rebalancing plan

A small documentation example has been added, together with the unit tests.

For reference, see the [Rebalancing Section](https://www.arangodb.com/docs/stable/http/cluster.html#rebalance) of the official documentation.