### PR TITLE
Fix `graph.vertex_collections` docstring

### DIFF
--- a/arango/graph.py
+++ b/arango/graph.py
@@ -107,9 +107,9 @@ class Graph(ApiGroup):
         return self._execute(request, response_handler)
 
     def vertex_collections(self) -> Result[List[str]]:
-        """Return vertex collections in the graph that are not orphaned.
+        """Return vertex collections in the graph.
 
-        :return: Names of vertex collections that are not orphaned.
+        :return: Names of vertex collections in Edge Definitions and Orphan Collections.
         :rtype: [str]
         :raise arango.exceptions.VertexCollectionListError: If retrieval fails.
         """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -330,6 +330,7 @@ def test_create_graph_with_edge_definition(db):
         orphan_collections=[ovcol_name],
     )
     assert edge_definition in new_graph.edge_definitions()
+    assert ovcol_name in new_graph.vertex_collections()
 
 
 def test_vertex_management(fvcol, bad_fvcol, fvdocs):


### PR DESCRIPTION
It was previously stated that the `graph.vertex_collections()` method excluded orphan collections, which is not/no longer the case

not sure when this has changed however