### PR TITLE
Authenticate using User JWT-Token

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -171,6 +171,7 @@ class ArangoClient:
         password: str = "",
         verify: bool = False,
         auth_method: str = "basic",
+        user_token: Optional[str] = None,
         superuser_token: Optional[str] = None,
         verify_certificate: bool = True,
     ) -> StandardDatabase:
@@ -189,6 +190,10 @@ class ArangoClient:
             refreshed automatically using ArangoDB username and password. This
             assumes that the clocks of the server and client are synchronized.
         :type auth_method: str
+        :param user_token: User generated token for user access.
+            If set, parameters **username**, **password** and **auth_method**
+            are ignored. This token is not refreshed automatically.
+        :type user_token: str
         :param superuser_token: User generated token for superuser access.
             If set, parameters **username**, **password** and **auth_method**
             are ignored. This token is not refreshed automatically.
@@ -212,6 +217,17 @@ class ArangoClient:
                 serializer=self._serializer,
                 deserializer=self._deserializer,
                 superuser_token=superuser_token,
+            )
+        elif user_token is not None:
+            connection = JwtConnection(
+                hosts=self._hosts,
+                host_resolver=self._host_resolver,
+                sessions=self._sessions,
+                db_name=name,
+                http_client=self._http,
+                serializer=self._serializer,
+                deserializer=self._deserializer,
+                user_token=user_token,
             )
         elif auth_method.lower() == "basic":
             connection = BasicConnection(

--- a/arango/client.py
+++ b/arango/client.py
@@ -192,7 +192,9 @@ class ArangoClient:
         :type auth_method: str
         :param user_token: User generated token for user access.
             If set, parameters **username**, **password** and **auth_method**
-            are ignored. This token is not refreshed automatically.
+            are ignored. This token is not refreshed automatically. If automatic
+            token refresh is required, consider setting **auth_method** to "jwt"
+            and using the **username** and **password** parameters instead.
         :type user_token: str
         :param superuser_token: User generated token for superuser access.
             If set, parameters **username**, **password** and **auth_method**

--- a/arango/client.py
+++ b/arango/client.py
@@ -194,11 +194,13 @@ class ArangoClient:
             If set, parameters **username**, **password** and **auth_method**
             are ignored. This token is not refreshed automatically. If automatic
             token refresh is required, consider setting **auth_method** to "jwt"
-            and using the **username** and **password** parameters instead.
+            and using the **username** and **password** parameters instead. Token
+            expiry will be checked.
         :type user_token: str
         :param superuser_token: User generated token for superuser access.
             If set, parameters **username**, **password** and **auth_method**
-            are ignored. This token is not refreshed automatically.
+            are ignored. This token is not refreshed automatically. Token
+            expiry will not be checked.
         :type superuser_token: str
         :param verify_certificate: Verify TLS certificates.
         :type verify_certificate: bool

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -501,4 +501,4 @@ class JwtSuperuserConnection(BaseConnection):
         except ExpiredSignatureError:
             raise JWTExpiredError("JWT token is expired")
 
-        self._auth_header = f"bearer {self._token}"
+        self._auth_header = f"bearer {token}"

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -13,10 +13,16 @@ from abc import abstractmethod
 from typing import Any, Callable, Optional, Sequence, Set, Tuple, Union
 
 import jwt
+from jwt.exceptions import ExpiredSignatureError
 from requests import ConnectionError, Session
 from requests_toolbelt import MultipartEncoder
 
-from arango.exceptions import JWTAuthError, ServerConnectionError
+from arango.exceptions import (
+    JWTAuthError,
+    JWTExpiredError,
+    JWTRefreshError,
+    ServerConnectionError,
+)
 from arango.http import HTTPClient
 from arango.request import Request
 from arango.resolver import HostResolver
@@ -300,11 +306,12 @@ class JwtConnection(BaseConnection):
         host_resolver: HostResolver,
         sessions: Sequence[Session],
         db_name: str,
-        username: str,
-        password: str,
         http_client: HTTPClient,
         serializer: Callable[..., str],
         deserializer: Callable[[str], Any],
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        user_token: Optional[str] = None,
     ) -> None:
         super().__init__(
             hosts,
@@ -323,7 +330,13 @@ class JwtConnection(BaseConnection):
         self._token: Optional[str] = None
         self._token_exp: int = sys.maxsize
 
-        self.refresh_token()
+        if user_token is not None:
+            self.set_token(user_token)
+        elif username is not None and password is not None:
+            self.refresh_token()
+        else:
+            m = "Either **user_token** or **username** & **password** must be set"
+            raise ValueError(m)
 
     def send_request(self, request: Request) -> Response:
         """Send an HTTP request to ArangoDB server.
@@ -360,7 +373,12 @@ class JwtConnection(BaseConnection):
 
         :return: JWT token.
         :rtype: str
+        :raise arango.exceptions.JWTRefreshError: If missing username & password.
+        :raise arango.exceptions.JWTAuthError: If token retrieval fails.
         """
+        if self._username is None or self._password is None:
+            raise JWTRefreshError("username and password must be set")
+
         request = Request(
             method="post",
             endpoint="/_open/auth",
@@ -374,21 +392,34 @@ class JwtConnection(BaseConnection):
         if not resp.is_success:
             raise JWTAuthError(resp, request)
 
-        self._token = resp.body["jwt"]
-        assert self._token is not None
+        self.set_token(resp.body["jwt"])
 
-        jwt_payload = jwt.decode(
-            self._token,
-            issuer="arangodb",
-            algorithms=["HS256"],
-            options={
-                "require_exp": True,
-                "require_iat": True,
-                "verify_iat": True,
-                "verify_exp": True,
-                "verify_signature": False,
-            },
-        )
+    def set_token(self, token: str) -> None:
+        """Set the JWT token.
+
+        :param token: JWT token.
+        :type token: str
+        :raise arango.exceptions.JWTExpiredError: If the token is expired.
+        """
+        assert token is not None
+
+        try:
+            jwt_payload = jwt.decode(
+                token,
+                issuer="arangodb",
+                algorithms=["HS256"],
+                options={
+                    "require_exp": True,
+                    "require_iat": True,
+                    "verify_iat": True,
+                    "verify_exp": True,
+                    "verify_signature": False,
+                },
+            )
+        except ExpiredSignatureError:
+            raise JWTExpiredError("JWT token is expired")
+
+        self._token = token
         self._token_exp = jwt_payload["exp"]
         self._auth_header = f"bearer {self._token}"
 

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -209,7 +209,7 @@ class BaseConnection:
         request = Request(method="get", endpoint="/_api/collection")
         resp = self.send_request(request)
         if resp.status_code in {401, 403}:
-            raise ServerConnectionError("bad username and/or password")
+            raise ServerConnectionError("bad username/password or token is expired")
         if not resp.is_success:  # pragma: no cover
             raise ServerConnectionError(resp.error_message or "bad server response")
         return resp.status_code

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -1014,3 +1014,11 @@ class JWTSecretListError(ArangoServerError):
 
 class JWTSecretReloadError(ArangoServerError):
     """Failed to reload JWT secrets."""
+
+
+class JWTRefreshError(ArangoClientError):
+    """Failed to refresh JWT token."""
+
+
+class JWTExpiredError(ArangoClientError):
+    """JWT token has expired."""

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -93,5 +93,25 @@ User generated JWT token can be used for user and superuser access.
     # Connect to "test" database as user using the token.
     db = client.db('test', user_token=token)
 
-    # Manually set the token (JwtConnection only).
+User and superuser tokens can be set on the connection object as well.
+
+**Example:**
+
+.. code-block:: python
+
+    from arango import ArangoClient
+
+    # Initialize the ArangoDB client.
+    client = ArangoClient()
+
+    # Connect to "test" database as superuser using the token.
+    db = client.db('test', user_token='token')
+
+    # Set the user token on the connection object.
     db.conn.set_token('new token')
+
+    # Connect to "test" database as superuser using the token.
+    db = client.db('test', superuser_token='superuser token')
+
+    # Set the user token on the connection object.
+    db.conn.set_token('new superuser token')

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -40,7 +40,6 @@ to work correctly.
 
 .. testcode::
     from arango import ArangoClient
-    import os
 
     # Initialize the ArangoDB client.
     client = ArangoClient()
@@ -60,11 +59,7 @@ to work correctly.
     # compensate for out-of-sync clocks between the client and server.
     db.conn.ext_leeway = 2
 
-    # It is also possible to connect via a pre-generated JWT.
-    token = os.environ["ARANGODB_USER_JWT"]
-    db = client.db('test', user_token=token)
-
-User generated JWT token can be used for superuser access.
+User generated JWT token can be used for user and superuser access.
 
 **Example:**
 
@@ -94,3 +89,9 @@ User generated JWT token can be used for superuser access.
 
     # Connect to "test" database as superuser using the token.
     db = client.db('test', superuser_token=token)
+
+    # Connect to "test" database as user using the token.
+    db = client.db('test', user_token=token)
+
+    # Manually set the token (JwtConnection only).
+    db.conn.set_token('new token')

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -40,6 +40,7 @@ to work correctly.
 
 .. testcode::
     from arango import ArangoClient
+    import os
 
     # Initialize the ArangoDB client.
     client = ArangoClient()
@@ -58,6 +59,10 @@ to work correctly.
     # Override the token expiry compare leeway in seconds (default: 0) to
     # compensate for out-of-sync clocks between the client and server.
     db.conn.ext_leeway = 2
+
+    # It is also possible to connect via a pre-generated JWT.
+    token = os.environ["ARANGODB_USER_JWT"]
+    db = client.db('test', user_token=token)
 
 User generated JWT token can be used for superuser access.
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -139,3 +139,8 @@ def test_auth_jwt_expiry(client, db_name, root_password, secret):
     # Test correct error on token expiry (user).
     with assert_raises(JWTExpiredError) as err:
         db = client.db("_system", user_token=expired_token)
+
+    # Test set_token() with expired token.
+    db = client.db("_system", user_token=generate_jwt(secret))
+    with assert_raises(JWTExpiredError) as err:
+        db.conn.set_token(expired_token)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,11 +5,11 @@ from arango.exceptions import (
     JWTExpiredError,
     JWTSecretListError,
     JWTSecretReloadError,
+    ServerConnectionError,
     ServerEncryptionError,
     ServerTLSError,
     ServerTLSReloadError,
     ServerVersionError,
-    ServerConnectionError,
 )
 from tests.helpers import assert_raises, generate_jwt, generate_string
 


### PR DESCRIPTION
Closes #238 

Introduces a `user_token` parameter to the `arango.client.ArangoClient.db` method to build a `JwtConnection` object without a `username/password` and without `auth_method="jwt"`

also introduces `set_token` to `arango.connection.JwtConnection` and `arango.connection.JwtSuperuserConnection`


```py
import os
from arango import ArangoClient

token = os.environ["ARANGODB_USER_JWT"]
db = ArangoClient().db(user_token=token)
db = ArangoClient().db(username=..., password=..., user_token=token) # Valid, but ignores `username` and `password` params

db.conn.set_token(token=...) # Valid
db.conn.refresh_token() # Raises `arango.exceptions.JWTRefreshError`, since `username/password` is not set
ArangoClient().db(user_token=expired_token) # Raises `JWTExpiredError`
```