### PR TITLE
update `/metrics` endpoint to `v2`

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -11,6 +11,8 @@ from numbers import Number
 from typing import Any, List, Optional, Sequence, Union
 from warnings import warn
 
+from packaging import version
+
 from arango.api import ApiGroup
 from arango.aql import AQL
 from arango.backup import Backup
@@ -838,6 +840,10 @@ class Database(ApiGroup):
         :return: Server metrics in Prometheus format.
         :rtype: str
         """
+        if version.parse(self.version()) < version.parse("3.10"):
+            m = "You are using the Metrics V2 API with a database version less than 3.10. The old metrics format is not available anymore."  # noqa: E501
+            warn(m, DeprecationWarning, stacklevel=2)
+
         request = Request(method="get", endpoint="/_admin/metrics/v2")
 
         def response_handler(resp: Response) -> str:

--- a/arango/database.py
+++ b/arango/database.py
@@ -11,8 +11,6 @@ from numbers import Number
 from typing import Any, List, Optional, Sequence, Union
 from warnings import warn
 
-from packaging import version
-
 from arango.api import ApiGroup
 from arango.aql import AQL
 from arango.backup import Backup
@@ -840,11 +838,6 @@ class Database(ApiGroup):
         :return: Server metrics in Prometheus format.
         :rtype: str
         """
-        db_version: str = str(self.version()).split("-")[0]
-        if version.parse(db_version) < version.parse("3.10"):
-            m = "You are using the Metrics V2 API with a database version less than 3.10. The old metrics format is not available anymore."  # noqa: E501
-            warn(m, DeprecationWarning, stacklevel=2)
-
         request = Request(method="get", endpoint="/_admin/metrics/v2")
 
         def response_handler(resp: Response) -> str:

--- a/arango/database.py
+++ b/arango/database.py
@@ -840,7 +840,8 @@ class Database(ApiGroup):
         :return: Server metrics in Prometheus format.
         :rtype: str
         """
-        if version.parse(self.version()) < version.parse("3.10"):
+        db_version: str = str(self.version()).split("-")[0]
+        if version.parse(db_version) < version.parse("3.10"):
             m = "You are using the Metrics V2 API with a database version less than 3.10. The old metrics format is not available anymore."  # noqa: E501
             warn(m, DeprecationWarning, stacklevel=2)
 

--- a/arango/database.py
+++ b/arango/database.py
@@ -838,7 +838,7 @@ class Database(ApiGroup):
         :return: Server metrics in Prometheus format.
         :rtype: str
         """
-        request = Request(method="get", endpoint="/_admin/metrics")
+        request = Request(method="get", endpoint="/_admin/metrics/v2")
 
         def response_handler(resp: Response) -> str:
             if resp.is_success:


### PR DESCRIPTION
> Since ArangoDB 3.8, there have been two APIs for retrieving the metrics in two different formats: /_admin/metrics and /_admin/metrics/v2. The metrics API v1 (/_admin/metrics) was deprecated in 3.8 and the usage of /_admin/metrics/v2 was encouraged.

> In ArangoDB 3.10, /_admin/metrics and /_admin/metrics/v2 now behave identically and return the same output in a fully Prometheus-compatible format. The old metrics format is not available anymore.

Ref: https://docs.arangodb.com/3.11/release-notes/version-3.10/api-changes-in-3-10/#endpoint-return-value-changes