### PR TITLE
DE-743 | MDI/ZKD Indexes

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1620,10 +1620,9 @@ class Collection(ApiGroup):
     def add_zkd_index(
         self,
         fields: Sequence[str],
-        field_value_types: str,
-        unique: Optional[bool] = None,
-        deduplicate: Optional[bool] = None,
+        field_value_types: str = "double",
         name: Optional[str] = None,
+        unique: Optional[bool] = None,
         in_background: Optional[bool] = None,
     ) -> Result[Json]:
         """Create a new ZKD Index.
@@ -1632,15 +1631,12 @@ class Collection(ApiGroup):
             order of the fields does not matter.
         :type fields: Sequence[str]
         :param field_value_types: The type of the field values. The only allowed
-            value is "double" at the moment.
+            value is "double" at the moment. Defaults to "double".
         :type field_value_types: str
-        :param unique: Whether the index is unique.
-        :type unique: bool | None
-        :param deduplicate: If set to True, inserting duplicate index values
-            from the same document triggers unique constraint errors.
-        :type deduplicate: bool | None
         :param name: Optional name for the index.
         :type name: str | None
+        :param unique: Whether the index is unique.
+        :type unique: bool | None
         :param in_background: Do not hold the collection lock.
         :type in_background: bool | None
         :return: New index details.
@@ -1655,8 +1651,6 @@ class Collection(ApiGroup):
 
         if unique is not None:
             data["unique"] = unique
-        if deduplicate is not None:
-            data["deduplicate"] = deduplicate
         if name is not None:
             data["name"] = name
         if in_background is not None:
@@ -1667,12 +1661,10 @@ class Collection(ApiGroup):
     def add_mdi_index(
         self,
         fields: Sequence[str],
-        field_value_types: str,
-        unique: Optional[bool] = None,
-        deduplicate: Optional[bool] = None,
+        field_value_types: str = "double",
         name: Optional[str] = None,
+        unique: Optional[bool] = None,
         in_background: Optional[bool] = None,
-        stored_values: Optional[Sequence[str]] = None,
     ) -> Result[Json]:
         """Create a new MDI index, previously known as ZKD index. This method
             is only usable with ArangoDB 3.12 and later.
@@ -1681,19 +1673,14 @@ class Collection(ApiGroup):
             order of the fields does not matter.
         :type fields: Sequence[str]
         :param field_value_types: The type of the field values. The only allowed
-            value is "double" at the moment.
+            value is "double" at the moment. Defaults to "double".
         :type field_value_types: str
-        :param unique: Whether the index is unique.
-        :type unique: bool | None
-        :param deduplicate: If set to True, inserting duplicate index values
-            from the same document triggers unique constraint errors.
-        :type deduplicate: bool | None
         :param name: Optional name for the index.
         :type name: str | None
+        :param unique: Whether the index is unique.
+        :type unique: bool | None
         :param in_background: Do not hold the collection lock.
         :type in_background: bool | None
-        :param stored_values: TODO
-        :type stored_values: TODO
         :return: New index details.
         :rtype: dict
         :raise arango.exceptions.IndexCreateError: If create fails.
@@ -1706,14 +1693,10 @@ class Collection(ApiGroup):
 
         if unique is not None:
             data["unique"] = unique
-        if deduplicate is not None:
-            data["deduplicate"] = deduplicate
         if name is not None:
             data["name"] = name
         if in_background is not None:
             data["inBackground"] = in_background
-        if stored_values is not None:
-            data["storedValues"] = stored_values
 
         return self._add_index(data)
 

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1617,6 +1617,106 @@ class Collection(ApiGroup):
 
         return self._add_index(data)
 
+    def add_zkd_index(
+        self,
+        fields: Sequence[str],
+        field_value_types: str,
+        unique: Optional[bool] = None,
+        deduplicate: Optional[bool] = None,
+        name: Optional[str] = None,
+        in_background: Optional[bool] = None,
+    ) -> Result[Json]:
+        """Create a new ZKD Index.
+
+        :param fields: Document fields to index. Unlike for other indexes the
+            order of the fields does not matter.
+        :type fields: Sequence[str]
+        :param field_value_types: The type of the field values. The only allowed
+            value is "double" at the moment.
+        :type field_value_types: str
+        :param unique: Whether the index is unique.
+        :type unique: bool | None
+        :param deduplicate: If set to True, inserting duplicate index values
+            from the same document triggers unique constraint errors.
+        :type deduplicate: bool | None
+        :param name: Optional name for the index.
+        :type name: str | None
+        :param in_background: Do not hold the collection lock.
+        :type in_background: bool | None
+        :return: New index details.
+        :rtype: dict
+        :raise arango.exceptions.IndexCreateError: If create fails.
+        """
+        data: Json = {
+            "type": "zkd",
+            "fields": fields,
+            "fieldValueTypes": field_value_types,
+        }
+
+        if unique is not None:
+            data["unique"] = unique
+        if deduplicate is not None:
+            data["deduplicate"] = deduplicate
+        if name is not None:
+            data["name"] = name
+        if in_background is not None:
+            data["inBackground"] = in_background
+
+        return self._add_index(data)
+
+    def add_mdi_index(
+        self,
+        fields: Sequence[str],
+        field_value_types: str,
+        unique: Optional[bool] = None,
+        deduplicate: Optional[bool] = None,
+        name: Optional[str] = None,
+        in_background: Optional[bool] = None,
+        stored_values: Optional[Sequence[str]] = None,
+    ) -> Result[Json]:
+        """Create a new MDI index, previously known as ZKD index. This method
+            is only usable with ArangoDB 3.12 and later.
+
+        :param fields: Document fields to index. Unlike for other indexes the
+            order of the fields does not matter.
+        :type fields: Sequence[str]
+        :param field_value_types: The type of the field values. The only allowed
+            value is "double" at the moment.
+        :type field_value_types: str
+        :param unique: Whether the index is unique.
+        :type unique: bool | None
+        :param deduplicate: If set to True, inserting duplicate index values
+            from the same document triggers unique constraint errors.
+        :type deduplicate: bool | None
+        :param name: Optional name for the index.
+        :type name: str | None
+        :param in_background: Do not hold the collection lock.
+        :type in_background: bool | None
+        :param stored_values: TODO
+        :type stored_values: TODO
+        :return: New index details.
+        :rtype: dict
+        :raise arango.exceptions.IndexCreateError: If create fails.
+        """
+        data: Json = {
+            "type": "mdi",
+            "fields": fields,
+            "fieldValueTypes": field_value_types,
+        }
+
+        if unique is not None:
+            data["unique"] = unique
+        if deduplicate is not None:
+            data["deduplicate"] = deduplicate
+        if name is not None:
+            data["name"] = name
+        if in_background is not None:
+            data["inBackground"] = in_background
+        if stored_values is not None:
+            data["storedValues"] = stored_values
+
+        return self._add_index(data)
+
     def delete_index(self, index_id: str, ignore_missing: bool = False) -> Result[bool]:
         """Delete an index.
 

--- a/arango/formatter.py
+++ b/arango/formatter.py
@@ -101,6 +101,8 @@ def format_index(body: Json) -> Json:
         result["writebuffer_active"] = body["writebufferActive"]
     if "writebufferSizeMax" in body:
         result["writebuffer_max_size"] = body["writebufferSizeMax"]
+    if "fieldValueTypes" in body:
+        result["field_value_types"] = body["fieldValueTypes"]
 
     return verify_format(body, result)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def pytest_configure(config):
     global_data.username = username
     global_data.password = password
     global_data.db_name = tst_db_name
-    global_data.db_version = version.parse(db_version)
+    global_data.db_version = version.parse(db_version.split("-")[0])
     global_data.sys_db = sys_db
     global_data.tst_db = tst_db
     global_data.bad_db = bad_db

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -264,7 +264,6 @@ def test_add_zkd_index(icol, db_version):
         "fields": ["x", "y", "z"],
         "unique": True,
         "new": True,
-        "sparse": False,
     }
 
     for key, value in expected_index.items():
@@ -298,7 +297,6 @@ def test_add_mdi_index(icol, db_version):
         "fields": ["x", "y", "z"],
         "unique": True,
         "new": True,
-        "sparse": False,
     }
 
     for key, value in expected_index.items():

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -253,17 +253,16 @@ def test_add_zkd_index(icol, db_version):
         name="zkd_index",
         fields=["x", "y", "z"],
         field_value_types="double",
-        unique=True,
-        deduplicate=True,
         in_background=False,
+        unique=False,
     )
 
     expected_index = {
         "name": "zkd_index",
         "type": "zkd",
         "fields": ["x", "y", "z"],
-        "unique": True,
         "new": True,
+        "unique": False,
     }
 
     for key, value in expected_index.items():
@@ -286,17 +285,16 @@ def test_add_mdi_index(icol, db_version):
         name="mdi_index",
         fields=["x", "y", "z"],
         field_value_types="double",
-        unique=True,
-        deduplicate=True,
         in_background=False,
+        unique=True,
     )
 
     expected_index = {
         "name": "mdi_index",
-        "type": "zkd",
+        "type": "mdi",
         "fields": ["x", "y", "z"],
-        "unique": True,
         "new": True,
+        "unique": True,
     }
 
     for key, value in expected_index.items():


### PR DESCRIPTION
Internal discussions have established that an `mdi` index is an alias for a `zkd` index, similar to the `hash` index & `persistent` index situation.

Given that python-arango never had support for `zkd` index creation, this PR introduces both `add_zkd_index` and `add_mdi_index`

i.e
- MDI (>=3.12)
- ZKD (<3.12)

Ref: https://docs.arangodb.com/3.12/index-and-search/indexing/working-with-indexes/multi-dimensional-indexes/

Happy to address this in another way, perhaps there's no need for 2 methods?