### PR TITLE
breaking: fix `geoJson` parameter

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1385,7 +1385,9 @@ class Collection(ApiGroup):
             with at least two floats. Documents with missing fields or invalid
             values are excluded.
         :type fields: str | [str]
-        :param geo_json: Whether to use GeoJSON data-format or not.
+        :param geo_json: Whether to use GeoJSON data-format or not. This
+            parameter has been renamed from `ordered`. See Github Issue
+            #234 for more details.
         :type geo_json: bool | None
         :param name: Optional name for the index.
         :type name: str | None

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1373,7 +1373,7 @@ class Collection(ApiGroup):
     def add_geo_index(
         self,
         fields: Fields,
-        ordered: Optional[bool] = None,
+        geo_json: Optional[bool] = None,
         name: Optional[str] = None,
         in_background: Optional[bool] = None,
         legacyPolygons: Optional[bool] = False,
@@ -1385,8 +1385,8 @@ class Collection(ApiGroup):
             with at least two floats. Documents with missing fields or invalid
             values are excluded.
         :type fields: str | [str]
-        :param ordered: Whether the order is longitude, then latitude.
-        :type ordered: bool | None
+        :param geo_json: Whether to use GeoJSON data-format or not.
+        :type geo_json: bool | None
         :param name: Optional name for the index.
         :type name: str | None
         :param in_background: Do not hold the collection lock.
@@ -1400,8 +1400,8 @@ class Collection(ApiGroup):
         """
         data: Json = {"type": "geo", "fields": fields}
 
-        if ordered is not None:
-            data["geoJson"] = ordered
+        if geo_json is not None:
+            data["geoJson"] = geo_json
         if name is not None:
             data["name"] = name
         if in_background is not None:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -107,7 +107,7 @@ def test_add_skiplist_index(icol):
 def test_add_geo_index(icol):
     # Test add geo index with one attribute
     result = icol.add_geo_index(
-        fields=["attr1"], ordered=False, name="geo_index", in_background=True
+        fields=["attr1"], geo_json=True, name="geo_index", in_background=True
     )
 
     expected_index = {
@@ -115,7 +115,7 @@ def test_add_geo_index(icol):
         "type": "geo",
         "fields": ["attr1"],
         "unique": False,
-        "geo_json": False,
+        "geo_json": True,
         "name": "geo_index",
     }
     for key, value in expected_index.items():
@@ -126,7 +126,7 @@ def test_add_geo_index(icol):
     # Test add geo index with two attributes
     result = icol.add_geo_index(
         fields=["attr1", "attr2"],
-        ordered=False,
+        geo_json=False,
     )
     expected_index = {
         "sparse": True,


### PR DESCRIPTION
Closes https://github.com/ArangoDB-Community/python-arango/issues/234

Not sure how else to handle this

We are currently using the parameter name `ordered` to specify whether a Geo Index should be created using GeoJson data-format or not, which can be confusing to users.

This PR just renames the parameter to `geo_json`

Ref: https://docs.arangodb.com/3.11/index-and-search/indexing/working-with-indexes/geo-spatial-indexes/