### PR TITLE
re-structure `Contents` in `index.rst`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,42 +23,74 @@ Installation
 Contents
 ========
 
+Basics
+
 .. toctree::
     :maxdepth: 1
 
     overview
     database
     collection
-    document
-    schema
     indexes
+    document
     graph
-    aql
     simple
-    cursor
+    aql
+
+Specialized Features
+
+.. toctree::
+    :maxdepth: 1
+
+    pregel
+    foxx
+    replication
+    transaction
+    cluster
+    analyzer
+    view
+    wal
+
+API Executions
+
+.. toctree::
+    :maxdepth: 1
+
     async
     batch
     overload
-    transaction
+
+Administration
+
+.. toctree::
+    :maxdepth: 1
+
     admin
     user
+
+Miscellaneous
+
+.. toctree::
+    :maxdepth: 1
+
     task
-    wal
-    pregel
-    foxx
-    view
-    analyzer
     threading
     certificates
     errors
     logging
     auth
     http
-    replication
-    cluster
     serializer
+    schema
+    cursor
     backup
     errno
+
+Development
+
+.. toctree::
+    :maxdepth: 1
+
     contributing
     specs
 


### PR DESCRIPTION
Grouping similar `rst` files together, happy to accept feedback

[Before](https://docs.python-arango.com/en/main/#contents)

After:

![image](https://github.com/ArangoDB-Community/python-arango/assets/43019056/09fe6eb5-7c5c-4ee2-9138-e784ff0cc4ec)
