### PR TITLE
Pregel is deprecated starting from 3.12

### DIFF
--- a/docs/pregel.rst
+++ b/docs/pregel.rst
@@ -1,6 +1,10 @@
 Pregel
 ------
 
+.. warning::
+    Starting from ArangoDB 3.12, the Pregel API has been dropped.
+    Currently, the driver still supports it for the 3.10 and 3.11 versions, but note that it will be dropped eventually.
+
 Python-arango provides support for **Pregel**, ArangoDB module for distributed
 iterative graph processing. For more information, refer to `ArangoDB manual`_.
 

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -11,7 +11,10 @@ from arango.exceptions import (
 from tests.helpers import assert_raises, generate_string
 
 
-def test_pregel_attributes(db, username):
+def test_pregel_attributes(db, db_version, username):
+    if db_version >= version.parse("3.12.0"):
+        pytest.skip("Pregel is not tested in 3.12.0+")
+
     assert db.pregel.context in ["default", "async", "batch", "transaction"]
     assert db.pregel.username == username
     assert db.pregel.db_name == db.name
@@ -19,6 +22,9 @@ def test_pregel_attributes(db, username):
 
 
 def test_pregel_management(db, db_version, graph, cluster):
+    if db_version >= version.parse("3.12.0"):
+        pytest.skip("Pregel is not tested in 3.12.0+")
+
     if cluster:
         pytest.skip("Not tested in a cluster setup")
 


### PR DESCRIPTION
This PR disables the Pregel tests for newer ArangoDB versions and updates the docs such that users would be aware why the API doesn't work on 3.12+.